### PR TITLE
[Seminar/#6] 6주차 과제 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation 'com.auth0:java-jwt:4.4.0'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     implementation 'com.auth0:java-jwt:4.4.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 sourceSets {

--- a/src/main/java/org/sopt/article/controller/ArticleController.java
+++ b/src/main/java/org/sopt/article/controller/ArticleController.java
@@ -1,6 +1,6 @@
 package org.sopt.article.controller;
 
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.sopt.article.domain.Article;
 import org.sopt.article.domain.SearchType;
@@ -9,17 +9,16 @@ import org.sopt.article.dto.ArticleListResponse;
 import org.sopt.article.dto.ArticleResponse;
 import org.sopt.article.service.ArticleService;
 import org.sopt.global.dto.ApiResponse;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
 import java.util.List;
 
+@Tag(name = "Article", description = "아티클 API")
 @RestController
-@RequestMapping("/articles")
+@RequestMapping("/api/articles")
 public class ArticleController {
     private final ArticleService articleService;
 

--- a/src/main/java/org/sopt/article/controller/ArticleController.java
+++ b/src/main/java/org/sopt/article/controller/ArticleController.java
@@ -12,6 +12,7 @@ import org.sopt.global.dto.ApiResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -28,11 +29,11 @@ public class ArticleController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<ArticleResponse>> createArticle(
-            @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION) String authorization,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody ArticleCreateRequest request) {
 
 
-        Article newArticle = articleService.create(authorization, request);
+        Article newArticle = articleService.create(memberId, request);
         ArticleResponse response = ArticleResponse.from(newArticle);
 
         return ResponseEntity

--- a/src/main/java/org/sopt/article/controller/ArticleController.java
+++ b/src/main/java/org/sopt/article/controller/ArticleController.java
@@ -1,5 +1,6 @@
 package org.sopt.article.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import org.sopt.article.domain.Article;
 import org.sopt.article.domain.SearchType;
@@ -8,6 +9,7 @@ import org.sopt.article.dto.ArticleListResponse;
 import org.sopt.article.dto.ArticleResponse;
 import org.sopt.article.service.ArticleService;
 import org.sopt.global.dto.ApiResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,9 +28,11 @@ public class ArticleController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<ArticleResponse>> createArticle(
+            @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION) String authorization,
             @Valid @RequestBody ArticleCreateRequest request) {
 
-        Article newArticle = articleService.create(request);
+
+        Article newArticle = articleService.create(authorization, request);
         ArticleResponse response = ArticleResponse.from(newArticle);
 
         return ResponseEntity

--- a/src/main/java/org/sopt/article/dto/ArticleCreateRequest.java
+++ b/src/main/java/org/sopt/article/dto/ArticleCreateRequest.java
@@ -8,9 +8,6 @@ import org.sopt.global.deserializer.TagDeserializer;
 
 public record ArticleCreateRequest(
 
-        @NotNull(message = "userId는 필수 입력 항목입니다.")
-        Long userId,
-
         @NotBlank(message = "게시글 제목은 필수 입력 항목입니다.")
         String title,
 

--- a/src/main/java/org/sopt/article/exception/DuplicateArticleTitleException.java
+++ b/src/main/java/org/sopt/article/exception/DuplicateArticleTitleException.java
@@ -1,7 +1,14 @@
 package org.sopt.article.exception;
 
-public class DuplicateArticleTitleException extends IllegalArgumentException {
+import org.sopt.global.code.ErrorCode;
+import org.sopt.global.exception.BusinessException;
+
+public class DuplicateArticleTitleException extends BusinessException {
     public DuplicateArticleTitleException(String message) {
-        super(message);
+        super(ErrorCode.DUPLICATE_ARTICLE_TITLE);
+    }
+
+    public DuplicateArticleTitleException(ErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/org/sopt/article/service/ArticleService.java
+++ b/src/main/java/org/sopt/article/service/ArticleService.java
@@ -7,7 +7,7 @@ import org.sopt.article.dto.ArticleCreateRequest;
 import java.util.List;
 
 public interface ArticleService {
-    Article create(String authorization, ArticleCreateRequest request);
+    Article create(Long memberId, ArticleCreateRequest request);
     Article findById(Long articleId);
     List<Article> findAll();
     List<Article> search(SearchType title, String memberName);

--- a/src/main/java/org/sopt/article/service/ArticleService.java
+++ b/src/main/java/org/sopt/article/service/ArticleService.java
@@ -7,7 +7,7 @@ import org.sopt.article.dto.ArticleCreateRequest;
 import java.util.List;
 
 public interface ArticleService {
-    Article create(ArticleCreateRequest request);
+    Article create(String authorization, ArticleCreateRequest request);
     Article findById(Long articleId);
     List<Article> findAll();
     List<Article> search(SearchType title, String memberName);

--- a/src/main/java/org/sopt/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/sopt/article/service/ArticleServiceImpl.java
@@ -28,13 +28,11 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     @Transactional
-    public Article create(String authorization, ArticleCreateRequest request) {
-
-        MemberResponse memberResponse = authService.authenticateWithJwt(authorization);        articleValidator.validateNewArticle(request);
+    public Article create(Long memberId, ArticleCreateRequest request) {
 
         articleValidator.validateNewArticle(request);
 
-        Member member = memberRepository.findById(memberResponse.userId())
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 회원을 찾을 수 없습니다."));
 
         Article newArticle = Article.create(

--- a/src/main/java/org/sopt/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/sopt/article/service/ArticleServiceImpl.java
@@ -1,12 +1,15 @@
 package org.sopt.article.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.article.domain.SearchType;
 import org.sopt.article.service.validator.ArticleValidator;
+import org.sopt.global.auth.service.AuthService;
 import org.sopt.global.exception.EntityNotFoundException;
 import org.sopt.article.domain.Article;
 import org.sopt.article.dto.ArticleCreateRequest;
 import org.sopt.article.repository.ArticleRepository;
 import org.sopt.member.domain.Member;
+import org.sopt.member.dto.MemberResponse;
 import org.sopt.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,24 +18,23 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ArticleServiceImpl implements ArticleService {
     private final ArticleRepository articleRepository;
     private final MemberRepository memberRepository;
     private final ArticleValidator articleValidator;
-
-    public ArticleServiceImpl(ArticleRepository articleRepository, MemberRepository memberRepository, ArticleValidator articleValidator) {
-        this.articleRepository = articleRepository;
-        this.memberRepository = memberRepository;
-        this.articleValidator = articleValidator;
-    }
+    private final AuthService authService;
 
     @Override
     @Transactional
-    public Article create(ArticleCreateRequest request) {
+    public Article create(String authorization, ArticleCreateRequest request) {
+
+        MemberResponse memberResponse = authService.authenticateWithJwt(authorization);        articleValidator.validateNewArticle(request);
+
         articleValidator.validateNewArticle(request);
 
-        Member member = memberRepository.findById(request.userId())
+        Member member = memberRepository.findById(memberResponse.userId())
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 회원을 찾을 수 없습니다."));
 
         Article newArticle = Article.create(

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -18,13 +18,25 @@ public class AuthController {
     private final AuthService authService;
     private final JwtService jwtService;
 
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
+    @Operation(summary = "일반 로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<String>> login(
             @RequestParam("email") String email,
             @RequestParam("password") String password
     ) {
         MemberResponse member = authService.loginWithCredentials(email, password);
+        String token = jwtService.generateToken(member.userId(), member.email());
+
+        return ResponseEntity.ok(ApiResponse.ok(token));
+    }
+
+    @Operation(summary = "구글 로그인", description = "구글 OAuth 로그인하여 JWT 토큰을 발급받습니다.")
+    @PostMapping("/login/google")
+    public ResponseEntity<ApiResponse<String>> loginWithGoogle(
+            @RequestParam("code") String authorizationCode
+    ) {
+        MemberResponse member = authService.loginWithGoogle(authorizationCode);
+
         String token = jwtService.generateToken(member.userId(), member.email());
 
         return ResponseEntity.ok(ApiResponse.ok(token));

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import org.sopt.global.dto.ApiResponse;
 import org.sopt.member.dto.MemberResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,9 +22,6 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-    private final JwtService jwtService;
-
-    private static final long REFRESH_TOKEN_EXPIRES_IN_SECONDS = 1209600;
 
     @Operation(summary = "일반 로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
     @PostMapping("/login")
@@ -48,23 +46,16 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "로그아웃하고 Refresh Token을 삭제합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
-    ) {
-        MemberResponse member = authService.authenticateWithJwt(authorization);
-        authService.logout(member.userId());
-
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal Long memberId) {
+        authService.logout(memberId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @Operation(summary = "내 정보 조회", description = "JWT 토큰으로 인증하여 내 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<MemberResponse>> getMyInfo(
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
-    ) {
-        MemberResponse member = authService.authenticateWithJwt(authorization);
-
-        return ResponseEntity.ok(ApiResponse.ok(member));
+    public ResponseEntity<ApiResponse<MemberResponse>> getMyInfo(@AuthenticationPrincipal Long memberId) {
+        MemberResponse memberResponse = authService.getMemberById(memberId);
+        return ResponseEntity.ok(ApiResponse.ok(memberResponse));
     }
 }
 

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package org.sopt.global.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.global.auth.dto.GoogleLoginRequest;
@@ -8,16 +9,15 @@ import org.sopt.global.auth.dto.LoginRequest;
 import org.sopt.global.auth.dto.RefreshTokenRequest;
 import org.sopt.global.auth.dto.TokenResponse;
 import org.sopt.global.auth.service.AuthService;
-import org.sopt.global.auth.service.JwtService;
 import org.sopt.global.dto.ApiResponse;
 import org.sopt.member.dto.MemberResponse;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth", description = "인증 API")
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -1,133 +1,42 @@
 package org.sopt.global.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.HttpSession;
-
-import java.time.Duration;
-
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.sopt.global.dto.ApiResponse;
-import org.sopt.global.auth.service.JwtService;
-import org.sopt.member.dto.MemberResponse;
 import org.sopt.global.auth.service.AuthService;
+import org.sopt.global.auth.service.JwtService;
+import org.sopt.global.dto.ApiResponse;
+import org.sopt.member.dto.MemberResponse;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/auth")
 @RequiredArgsConstructor
-@Slf4j
 public class AuthController {
 
     private final AuthService authService;
     private final JwtService jwtService;
 
-    @Operation(summary = "헤더 기반 Basic-Authentication")
-    @PostMapping("/v1/login")
-    public ResponseEntity<ApiResponse<MemberResponse>> login(
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
-    ) {
-        log.info(authorization);
-        MemberResponse result = authService.login(authorization);
-        return ResponseEntity.ok(ApiResponse.ok(result));
-    }
-
-    @Operation(summary = "이메일/비밀번호 기반 로그인 (쿠키 발급)")
-    @PostMapping("/v2/login")
-    public ResponseEntity<ApiResponse<MemberResponse>> loginV2(
-            @RequestParam("email") String email,
-            @RequestParam("password") String password
-    ) {
-        MemberResponse result = authService.loginWithCredentials(email, password);
-
-        String credentials = email + ":" + password;
-
-        ResponseCookie cookie = ResponseCookie.from("basic", credentials)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Lax")
-                .maxAge(Duration.ofHours(1))
-                .path("/")
-                .build();
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(ApiResponse.ok(result));
-    }
-
-    @Operation(summary = "쿠키로 로그인 여부 확인")
-    @GetMapping("/v2/me")
-    public ResponseEntity<ApiResponse<MemberResponse>> checkSession(
-            @CookieValue(value = "basic", required = false) String basicCookie
-    ) {
-        if (basicCookie == null) {
-            throw new IllegalArgumentException("로그인 쿠키가 없습니다.");
-        }
-
-        int idx = basicCookie.indexOf(":");
-        if (idx < 0) {
-            throw new IllegalArgumentException("쿠키에 이메일과 비밀번호 구분자(:)가 없습니다.");
-        }
-        String email = basicCookie.substring(0, idx);
-        String password = basicCookie.substring(idx + 1);
-
-        log.info("[v2] 세션 확인, 이메일: {}", email);
-        MemberResponse result = authService.loginWithCredentials(email, password);
-        return ResponseEntity.ok(ApiResponse.ok(result));
-    }
-
-    @Operation(summary = "세션 기반 로그인 (JSESSIONID 발급)")
-    @PostMapping("/v3/login")
-    public ResponseEntity<ApiResponse<MemberResponse>> loginV3(
-            @RequestParam("email") String email,
-            @RequestParam("password") String password,
-            HttpSession session
-    ) {
-        MemberResponse result = authService.loginWithCredentials(email, password);
-        session.setAttribute("LOGIN_MEMBER_ID", result.userId());
-        return ResponseEntity.ok(ApiResponse.ok(result));
-    }
-
-    @Operation(summary = "세션 로그인 여부 확인")
-    @GetMapping("/v3/me")
-    public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV3(
-            HttpSession session
-    ) {
-        Long memberId = (Long) session.getAttribute("LOGIN_MEMBER_ID");
-        MemberResponse result = authService.getMemberById(memberId);
-        return ResponseEntity.ok(ApiResponse.ok(result));
-    }
-
-    @Operation(summary = "JWT 기반 로그인 (토큰 반환)")
-    @PostMapping("/v4/login")
-    public ResponseEntity<ApiResponse<String>> loginV4(
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<String>> login(
             @RequestParam("email") String email,
             @RequestParam("password") String password
     ) {
         MemberResponse member = authService.loginWithCredentials(email, password);
         String token = jwtService.generateToken(member.userId(), member.email());
+
         return ResponseEntity.ok(ApiResponse.ok(token));
     }
 
-    @Operation(summary = "JWT 검증 (Authorization: Bearer)")
-    @GetMapping("/v4/me")
-    public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV4(
+    @Operation(summary = "내 정보 조회", description = "JWT 토큰으로 인증하여 내 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> getMyInfo(
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
     ) {
-        String raw = null;
-        if (authorization != null && authorization.startsWith("Bearer ")) {
-            raw = authorization.substring("Bearer ".length()).trim();
-        }
+        MemberResponse member = authService.authenticateWithJwt(authorization);
 
-        Long memberId = jwtService.verifyAndGetMemberId(raw);
-        MemberResponse member = authService.getMemberById(memberId);
         return ResponseEntity.ok(ApiResponse.ok(member));
     }
 }

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -2,7 +2,9 @@ package org.sopt.global.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpSession;
+
 import java.time.Duration;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.global.dto.ApiResponse;
@@ -24,110 +26,110 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class AuthController {
 
-  private final AuthService authService;
-  private final JwtService jwtService;
+    private final AuthService authService;
+    private final JwtService jwtService;
 
-  @Operation(summary = "헤더 기반 Basic-Authentication")
-  @PostMapping("/v1/login")
-  public ResponseEntity<ApiResponse<MemberResponse>> login(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
-  ) {
-    log.info(authorization);
-    MemberResponse result = authService.login(authorization);
-    return ResponseEntity.ok(ApiResponse.ok(result));
-  }
-
-  @Operation(summary = "이메일/비밀번호 기반 로그인 (쿠키 발급)")
-  @PostMapping("/v2/login")
-  public ResponseEntity<ApiResponse<MemberResponse>> loginV2(
-      @RequestParam("email") String email,
-      @RequestParam("password") String password
-  ) {
-    MemberResponse result = authService.loginWithCredentials(email, password);
-
-    String credentials = email + ":" + password;
-
-    ResponseCookie cookie = ResponseCookie.from("basic", credentials)
-        .httpOnly(true)
-        .secure(true)
-        .sameSite("Lax")
-        .maxAge(Duration.ofHours(1))
-        .path("/")
-        .build();
-
-    return ResponseEntity.ok()
-        .header(HttpHeaders.SET_COOKIE, cookie.toString())
-        .body(ApiResponse.ok(result));
-  }
-
-  @Operation(summary = "쿠키로 로그인 여부 확인")
-  @GetMapping("/v2/me")
-  public ResponseEntity<ApiResponse<MemberResponse>> checkSession(
-      @CookieValue(value = "basic", required = false) String basicCookie
-  ) {
-    if (basicCookie == null) {
-      throw new IllegalArgumentException("로그인 쿠키가 없습니다.");
+    @Operation(summary = "헤더 기반 Basic-Authentication")
+    @PostMapping("/v1/login")
+    public ResponseEntity<ApiResponse<MemberResponse>> login(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
+    ) {
+        log.info(authorization);
+        MemberResponse result = authService.login(authorization);
+        return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
-    int idx = basicCookie.indexOf(":");
-    if (idx < 0) {
-      throw new IllegalArgumentException("쿠키에 이메일과 비밀번호 구분자(:)가 없습니다.");
-    }
-    String email = basicCookie.substring(0, idx);
-    String password = basicCookie.substring(idx + 1);
+    @Operation(summary = "이메일/비밀번호 기반 로그인 (쿠키 발급)")
+    @PostMapping("/v2/login")
+    public ResponseEntity<ApiResponse<MemberResponse>> loginV2(
+            @RequestParam("email") String email,
+            @RequestParam("password") String password
+    ) {
+        MemberResponse result = authService.loginWithCredentials(email, password);
 
-    log.info("[v2] 세션 확인, 이메일: {}", email);
-    MemberResponse result = authService.loginWithCredentials(email, password);
-    return ResponseEntity.ok(ApiResponse.ok(result));
-  }
+        String credentials = email + ":" + password;
 
-  @Operation(summary = "세션 기반 로그인 (JSESSIONID 발급)")
-  @PostMapping("/v3/login")
-  public ResponseEntity<ApiResponse<MemberResponse>> loginV3(
-      @RequestParam("email") String email,
-      @RequestParam("password") String password,
-      HttpSession session
-  ) {
-    MemberResponse result = authService.loginWithCredentials(email, password);
-    session.setAttribute("LOGIN_MEMBER_ID", result.userId());
-    return ResponseEntity.ok(ApiResponse.ok(result));
-  }
+        ResponseCookie cookie = ResponseCookie.from("basic", credentials)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .maxAge(Duration.ofHours(1))
+                .path("/")
+                .build();
 
-  @Operation(summary = "세션 로그인 여부 확인")
-  @GetMapping("/v3/me")
-  public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV3(
-      HttpSession session
-  ) {
-    Long memberId = (Long) session.getAttribute("LOGIN_MEMBER_ID");
-    MemberResponse result = authService.getMemberById(memberId);
-    return ResponseEntity.ok(ApiResponse.ok(result));
-  }
-
-  @Operation(summary = "JWT 기반 로그인 (토큰 반환)")
-  @PostMapping("/v4/login")
-  public ResponseEntity<ApiResponse<String>> loginV4(
-      @RequestParam("email") String email,
-      @RequestParam("password") String password
-  ) {
-    MemberResponse member = authService.loginWithCredentials(email, password);
-    String token = jwtService.generateToken(member.userId(), member.email());
-    return ResponseEntity.ok(ApiResponse.ok(token));
-  }
-
-  @Operation(summary = "JWT 검증 (Authorization: Bearer)")
-  @GetMapping("/v4/me")
-  public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV4(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
-  ) {
-    String raw = null;
-    if (authorization != null && authorization.startsWith("Bearer ")) {
-      raw = authorization.substring("Bearer ".length()).trim();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(ApiResponse.ok(result));
     }
 
-    Long memberId = jwtService.verifyAndGetMemberId(raw);
-    MemberResponse member = authService.getMemberById(memberId);
-    return ResponseEntity.ok(ApiResponse.ok(member));
-  }
+    @Operation(summary = "쿠키로 로그인 여부 확인")
+    @GetMapping("/v2/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> checkSession(
+            @CookieValue(value = "basic", required = false) String basicCookie
+    ) {
+        if (basicCookie == null) {
+            throw new IllegalArgumentException("로그인 쿠키가 없습니다.");
+        }
+
+        int idx = basicCookie.indexOf(":");
+        if (idx < 0) {
+            throw new IllegalArgumentException("쿠키에 이메일과 비밀번호 구분자(:)가 없습니다.");
+        }
+        String email = basicCookie.substring(0, idx);
+        String password = basicCookie.substring(idx + 1);
+
+        log.info("[v2] 세션 확인, 이메일: {}", email);
+        MemberResponse result = authService.loginWithCredentials(email, password);
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @Operation(summary = "세션 기반 로그인 (JSESSIONID 발급)")
+    @PostMapping("/v3/login")
+    public ResponseEntity<ApiResponse<MemberResponse>> loginV3(
+            @RequestParam("email") String email,
+            @RequestParam("password") String password,
+            HttpSession session
+    ) {
+        MemberResponse result = authService.loginWithCredentials(email, password);
+        session.setAttribute("LOGIN_MEMBER_ID", result.userId());
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @Operation(summary = "세션 로그인 여부 확인")
+    @GetMapping("/v3/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV3(
+            HttpSession session
+    ) {
+        Long memberId = (Long) session.getAttribute("LOGIN_MEMBER_ID");
+        MemberResponse result = authService.getMemberById(memberId);
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @Operation(summary = "JWT 기반 로그인 (토큰 반환)")
+    @PostMapping("/v4/login")
+    public ResponseEntity<ApiResponse<String>> loginV4(
+            @RequestParam("email") String email,
+            @RequestParam("password") String password
+    ) {
+        MemberResponse member = authService.loginWithCredentials(email, password);
+        String token = jwtService.generateToken(member.userId(), member.email());
+        return ResponseEntity.ok(ApiResponse.ok(token));
+    }
+
+    @Operation(summary = "JWT 검증 (Authorization: Bearer)")
+    @GetMapping("/v4/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV4(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
+    ) {
+        String raw = null;
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            raw = authorization.substring("Bearer ".length()).trim();
+        }
+
+        Long memberId = jwtService.verifyAndGetMemberId(raw);
+        MemberResponse member = authService.getMemberById(memberId);
+        return ResponseEntity.ok(ApiResponse.ok(member));
+    }
 }
 
 

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -1,4 +1,4 @@
-package org.sopt.global.controller;
+package org.sopt.global.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpSession;
@@ -6,9 +6,9 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.global.dto.ApiResponse;
-import org.sopt.global.service.JwtService;
+import org.sopt.global.auth.service.JwtService;
 import org.sopt.member.dto.MemberResponse;
-import org.sopt.global.service.AuthService;
+import org.sopt.global.auth.service.AuthService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -1,7 +1,10 @@
 package org.sopt.global.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.sopt.global.auth.dto.GoogleLoginRequest;
+import org.sopt.global.auth.dto.LoginRequest;
 import org.sopt.global.auth.dto.RefreshTokenRequest;
 import org.sopt.global.auth.dto.TokenResponse;
 import org.sopt.global.auth.service.AuthService;
@@ -24,32 +27,16 @@ public class AuthController {
 
     @Operation(summary = "일반 로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenResponse>> login(
-            @RequestParam("email") String email,
-            @RequestParam("password") String password
-    ) {
-        MemberResponse member = authService.loginWithCredentials(email, password);
-
-        String accessToken = jwtService.generateAccessToken(member.userId(), member.email());
-        String refreshToken = jwtService.generateRefreshToken(member.userId());
-
-        authService.saveRefreshToken(member.userId(), refreshToken, REFRESH_TOKEN_EXPIRES_IN_SECONDS);
-
-        TokenResponse tokenResponse = TokenResponse.of(accessToken, refreshToken);
-
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
+        TokenResponse tokenResponse = authService.login(request.email(), request.password());
         return ResponseEntity.ok(ApiResponse.ok(tokenResponse));
     }
 
     @Operation(summary = "구글 로그인", description = "구글 OAuth 로그인하여 JWT 토큰을 발급받습니다.")
     @PostMapping("/login/google")
-    public ResponseEntity<ApiResponse<String>> loginWithGoogle(
-            @RequestParam("code") String authorizationCode
-    ) {
-        MemberResponse member = authService.loginWithGoogle(authorizationCode);
-
-        String token = jwtService.generateToken(member.userId(), member.email());
-
-        return ResponseEntity.ok(ApiResponse.ok(token));
+    public ResponseEntity<ApiResponse<TokenResponse>> loginWithGoogle(@Valid @RequestBody GoogleLoginRequest request) {
+        TokenResponse tokenResponse = authService.loginWithGoogle(request.authorizationCode());
+        return ResponseEntity.ok(ApiResponse.ok(tokenResponse));
     }
 
     @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새로운 Access Token을 발급받습니다.")

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -41,9 +41,7 @@ public class AuthController {
 
     @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새로운 Access Token을 발급받습니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<TokenResponse>> refresh(
-            @RequestBody RefreshTokenRequest request
-    ) {
+    public ResponseEntity<ApiResponse<TokenResponse>> refresh(@Valid @RequestBody RefreshTokenRequest request) {
         TokenResponse tokenResponse = authService.refreshAccessToken(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.ok(tokenResponse));
     }

--- a/src/main/java/org/sopt/global/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package org.sopt.global.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.sopt.global.auth.dto.RefreshTokenRequest;
+import org.sopt.global.auth.dto.TokenResponse;
 import org.sopt.global.auth.service.AuthService;
 import org.sopt.global.auth.service.JwtService;
 import org.sopt.global.dto.ApiResponse;
@@ -18,16 +20,24 @@ public class AuthController {
     private final AuthService authService;
     private final JwtService jwtService;
 
+    private static final long REFRESH_TOKEN_EXPIRES_IN_SECONDS = 1209600;
+
     @Operation(summary = "일반 로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<String>> login(
+    public ResponseEntity<ApiResponse<TokenResponse>> login(
             @RequestParam("email") String email,
             @RequestParam("password") String password
     ) {
         MemberResponse member = authService.loginWithCredentials(email, password);
-        String token = jwtService.generateToken(member.userId(), member.email());
 
-        return ResponseEntity.ok(ApiResponse.ok(token));
+        String accessToken = jwtService.generateAccessToken(member.userId(), member.email());
+        String refreshToken = jwtService.generateRefreshToken(member.userId());
+
+        authService.saveRefreshToken(member.userId(), refreshToken, REFRESH_TOKEN_EXPIRES_IN_SECONDS);
+
+        TokenResponse tokenResponse = TokenResponse.of(accessToken, refreshToken);
+
+        return ResponseEntity.ok(ApiResponse.ok(tokenResponse));
     }
 
     @Operation(summary = "구글 로그인", description = "구글 OAuth 로그인하여 JWT 토큰을 발급받습니다.")
@@ -40,6 +50,26 @@ public class AuthController {
         String token = jwtService.generateToken(member.userId(), member.email());
 
         return ResponseEntity.ok(ApiResponse.ok(token));
+    }
+
+    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새로운 Access Token을 발급받습니다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> refresh(
+            @RequestBody RefreshTokenRequest request
+    ) {
+        TokenResponse tokenResponse = authService.refreshAccessToken(request.refreshToken());
+        return ResponseEntity.ok(ApiResponse.ok(tokenResponse));
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃하고 Refresh Token을 삭제합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
+    ) {
+        MemberResponse member = authService.authenticateWithJwt(authorization);
+        authService.logout(member.userId());
+
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @Operation(summary = "내 정보 조회", description = "JWT 토큰으로 인증하여 내 정보를 조회합니다.")

--- a/src/main/java/org/sopt/global/auth/domain/RefreshToken.java
+++ b/src/main/java/org/sopt/global/auth/domain/RefreshToken.java
@@ -1,0 +1,49 @@
+package org.sopt.global.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 500)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private RefreshToken(Long memberId, String token, LocalDateTime expiresAt) {
+        this.memberId = memberId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void updateToken(String newToken, LocalDateTime newExpiresAt) {
+        this.token = newToken;
+        this.expiresAt = newExpiresAt;
+    }
+}

--- a/src/main/java/org/sopt/global/auth/dto/GoogleLoginRequest.java
+++ b/src/main/java/org/sopt/global/auth/dto/GoogleLoginRequest.java
@@ -1,6 +1,5 @@
 package org.sopt.global.auth.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record GoogleLoginRequest(

--- a/src/main/java/org/sopt/global/auth/dto/GoogleLoginRequest.java
+++ b/src/main/java/org/sopt/global/auth/dto/GoogleLoginRequest.java
@@ -1,0 +1,10 @@
+package org.sopt.global.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record GoogleLoginRequest(
+        @NotBlank(message = "Authorization Code는 필수입니다.")
+        String authorizationCode
+) {
+}

--- a/src/main/java/org/sopt/global/auth/dto/GoogleTokenResponse.java
+++ b/src/main/java/org/sopt/global/auth/dto/GoogleTokenResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.global.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @JsonProperty("scope")
+        String scope,
+
+        @JsonProperty("refresh_token")
+        String refreshToken
+) {
+}

--- a/src/main/java/org/sopt/global/auth/dto/GoogleUserInfoResponse.java
+++ b/src/main/java/org/sopt/global/auth/dto/GoogleUserInfoResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.global.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleUserInfoResponse(
+        @JsonProperty("sub")
+        String sub,  // 구글 고유 ID
+
+        @JsonProperty("name")
+        String name,
+
+        @JsonProperty("email")
+        String email,
+
+        @JsonProperty("email_verified")
+        Boolean emailVerified,
+
+        @JsonProperty("picture")
+        String picture
+) {
+}

--- a/src/main/java/org/sopt/global/auth/dto/LoginRequest.java
+++ b/src/main/java/org/sopt/global/auth/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+package org.sopt.global.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password
+) {
+}

--- a/src/main/java/org/sopt/global/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/org/sopt/global/auth/dto/RefreshTokenRequest.java
@@ -1,6 +1,9 @@
 package org.sopt.global.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record RefreshTokenRequest(
+        @NotBlank(message = "Refresh Token을 입력해주세요.")
         String refreshToken
 ) {
 }

--- a/src/main/java/org/sopt/global/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/org/sopt/global/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,6 @@
+package org.sopt.global.auth.dto;
+
+public record RefreshTokenRequest(
+        String refreshToken
+) {
+}

--- a/src/main/java/org/sopt/global/auth/dto/TokenResponse.java
+++ b/src/main/java/org/sopt/global/auth/dto/TokenResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.global.auth.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/sopt/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/global/auth/filter/JwtAuthenticationFilter.java
@@ -51,6 +51,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        String authHeader = request.getHeader("Authorization");
+
+        // 토큰이 없거나 Bearer 타입이 아니면 검증 로직을 건너뛰고 다음 필터로 넘김
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try {
             String token = jwtService.extractTokenFromHeader(request.getHeader("Authorization"));
 

--- a/src/main/java/org/sopt/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/global/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,80 @@
+package org.sopt.global.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.auth.service.JwtService;
+import org.sopt.global.exception.ExpiredTokenException;
+import org.sopt.global.exception.InvalidTokenException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    private static final String[] EXCLUDED_PATH_PREFIXES = {
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/swagger-config",
+            "/swagger-resources"
+    };
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+
+        // Swagger 경로만 필터 건너뜀
+        for (String prefix : EXCLUDED_PATH_PREFIXES) {
+            if (uri.startsWith(prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            String token = jwtService.extractTokenFromHeader(request.getHeader("Authorization"));
+
+            if (token != null) {
+                Long memberId = jwtService.verifyAndGetMemberId(token);
+
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        memberId,
+                        null,
+                        Collections.emptyList()  // authorities (권한)
+                );
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("✅ JWT 인증 성공 - memberId: {}", memberId);
+            }
+
+        } catch (ExpiredTokenException | InvalidTokenException e) {
+            // JWT 검증 실패 시 request에 예외 정보 저장
+            // CustomAuthenticationEntryPoint에서 처리
+            request.setAttribute("exception", e);
+            log.debug("❌ JWT 검증 실패: {}", e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/sopt/global/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/sopt/global/auth/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,41 @@
+package org.sopt.global.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.code.ErrorCode;
+import org.sopt.global.dto.ApiResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+/* 권한 부족 시 (403 Forbidden) 처리 핸들러 */
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        response.setStatus(ErrorCode.FORBIDDEN.getStatusCode());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+
+        ApiResponse<Void> errorResponse = ApiResponse.of(ErrorCode.FORBIDDEN);
+        String json = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(json);
+
+        log.debug("❌ 권한 부족: {}", accessDeniedException.getMessage());
+    }
+}

--- a/src/main/java/org/sopt/global/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/global/auth/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,60 @@
+package org.sopt.global.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.code.ErrorCode;
+import org.sopt.global.dto.ApiResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+/* 인증 실패 시 (401 Unauthorized) 처리 핸들러 */
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        // JwtAuthenticationFilter에서 저장한 예외 정보 확인
+        Exception exception = (Exception) request.getAttribute("exception");
+
+        if (exception == null) {
+            setResponse(response, ErrorCode.UNAUTHORIZED);
+            return;
+        }
+
+        // 예외 타입에 따라 에러 응답 생성
+        if (exception instanceof org.sopt.global.exception.ExpiredTokenException) {
+            setResponse(response, ErrorCode.EXPIRED_TOKEN);
+        } else if (exception instanceof org.sopt.global.exception.InvalidTokenException) {
+            setResponse(response, ErrorCode.INVALID_TOKEN);
+        } else {
+            setResponse(response, ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatusCode());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+
+        ApiResponse<Void> errorResponse = ApiResponse.of(errorCode);
+        String json = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(json);
+
+        log.debug("❌ 인증 실패 응답: {} - {}", errorCode.getStatusCode(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/org/sopt/global/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/sopt/global/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package org.sopt.global.auth.repository;
+
+import org.sopt.global.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    Optional<RefreshToken> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -15,6 +15,8 @@ import org.sopt.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 
 @Service
@@ -55,7 +57,9 @@ public class AuthService {
     public TokenResponse loginWithGoogle(String authorizationCode) {
         log.info("구글 소셜 로그인 시작");
 
-        GoogleTokenResponse tokenResponse = googleOAuthService.getAccessToken(authorizationCode);
+        String decodedCode = URLDecoder.decode(authorizationCode, StandardCharsets.UTF_8);
+
+        GoogleTokenResponse tokenResponse = googleOAuthService.getAccessToken(decodedCode);
 
         GoogleUserInfoResponse userInfo = googleOAuthService.getUserInfo(
                 tokenResponse.accessToken()

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -1,22 +1,34 @@
 package org.sopt.global.auth.service;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.auth.dto.GoogleTokenResponse;
+import org.sopt.global.auth.dto.GoogleUserInfoResponse;
 import org.sopt.global.exception.UnauthorizedException;
+import org.sopt.member.domain.Gender;
 import org.sopt.member.domain.Member;
+import org.sopt.member.domain.Provider;
 import org.sopt.member.dto.MemberResponse;
 import org.sopt.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
+    private final GoogleOAuthService googleOAuthService;
 
+    // 소셜 로그인 기본값
+    private static final LocalDate DEFAULT_BIRTHDATE = LocalDate.of(2000, 1, 1);
+    private static final Gender DEFAULT_GENDER = Gender.OTHER;
+
+    /* 이메일과 비밀번호로 로그인 */
     public MemberResponse loginWithCredentials(String email, String password) {
         if (email == null || email.isBlank() || password == null || password.isBlank()) {
             throw new UnauthorizedException("이메일과 비밀번호를 모두 입력해주세요.");
@@ -25,6 +37,11 @@ public class AuthService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
+
+        if (member.isSocialMember()) {
+            throw new UnauthorizedException("소셜 로그인 회원입니다. " + member.getProvider() + " 로그인을 이용해주세요.");
+        }
+
         if (member.getPassword() == null || !member.getPassword().equals(password)) {
             throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
@@ -32,13 +49,51 @@ public class AuthService {
         return MemberResponse.from(member);
     }
 
-    public MemberResponse authenticateWithJwt(String authorization) {
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            throw new UnauthorizedException("유효하지 않은 인증 정보입니다.");
+    /* 구글 소셜 로그인 */
+    @Transactional
+    public MemberResponse loginWithGoogle(String authorizationCode) {
+        log.info("구글 소셜 로그인 시작");
+
+        GoogleTokenResponse tokenResponse = googleOAuthService.getAccessToken(authorizationCode);
+
+        GoogleUserInfoResponse userInfo = googleOAuthService.getUserInfo(tokenResponse.accessToken());
+
+        Member member = memberRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> createGoogleMember(userInfo));
+
+        // 기존 회원인데 다른 Provider인 경우 예외
+        if (member.getProvider() != Provider.GOOGLE) {
+            throw new UnauthorizedException("이미 " + member.getProvider() + " 계정으로 가입된 이메일입니다.");
         }
 
-        String token = authorization.substring("Bearer ".length()).trim();
+        log.info("구글 소셜 로그인 성공 - email: {}", member.getEmail());
+        return MemberResponse.from(member);
+    }
+
+    /* 구글 회원 생성 */
+    private Member createGoogleMember(GoogleUserInfoResponse userInfo) {
+        log.info("구글 신규 회원 생성 - email: {}", userInfo.email());
+
+        Member newMember = Member.createSocialMember(
+                userInfo.name(),
+                DEFAULT_BIRTHDATE,
+                userInfo.email(),
+                DEFAULT_GENDER,
+                Provider.GOOGLE,
+                userInfo.sub()
+        );
+
+        return memberRepository.save(newMember);
+    }
+
+    public MemberResponse authenticateWithJwt(String authorization) {
+        log.debug("Authorization header: {}", authorization);
+
+        String token = jwtService.extractTokenFromHeader(authorization);
+        log.debug("Extracted token: {}", token);
+
         Long memberId = jwtService.verifyAndGetMemberId(token);
+        log.debug("Member ID: {}", memberId);
 
         return getMemberById(memberId);
     }

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.global.auth.dto.GoogleTokenResponse;
 import org.sopt.global.auth.dto.GoogleUserInfoResponse;
+import org.sopt.global.auth.dto.TokenResponse;
+import org.sopt.global.exception.EntityNotFoundException;
 import org.sopt.global.exception.UnauthorizedException;
 import org.sopt.member.domain.Gender;
 import org.sopt.member.domain.Member;
@@ -23,10 +25,12 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
     private final GoogleOAuthService googleOAuthService;
+    private final RefreshTokenService refreshTokenService;
 
     // 소셜 로그인 기본값
     private static final LocalDate DEFAULT_BIRTHDATE = LocalDate.of(2000, 1, 1);
     private static final Gender DEFAULT_GENDER = Gender.OTHER;
+    private static final long REFRESH_TOKEN_EXPIRES_IN_SECONDS = 1209600;
 
     /* 이메일과 비밀번호로 로그인 */
     public MemberResponse loginWithCredentials(String email, String password) {
@@ -72,7 +76,9 @@ public class AuthService {
 
     /* 구글 회원 생성 */
     private Member createGoogleMember(GoogleUserInfoResponse userInfo) {
-        log.info("구글 신규 회원 생성 - email: {}", userInfo.email());
+        log.info("구글 신규 회원 생성");
+        log.info("Email: {}", userInfo.email());
+        log.info("Name: {}", userInfo.name());
 
         Member newMember = Member.createSocialMember(
                 userInfo.name(),
@@ -105,5 +111,35 @@ public class AuthService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
         return MemberResponse.from(member);
+    }
+
+    @Transactional
+    public TokenResponse refreshAccessToken(String refreshToken) {
+        log.info("Access Token 재발급 시작");
+
+        Long memberId = refreshTokenService.validateAndGetMemberId(refreshToken);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원이 존재하지 않습니다."));
+
+        String newAccessToken = jwtService.generateAccessToken(member.getId(), member.getEmail());
+
+        String newRefreshToken = jwtService.generateRefreshToken(member.getId());
+        refreshTokenService.saveOrUpdate(member.getId(), newRefreshToken, REFRESH_TOKEN_EXPIRES_IN_SECONDS);
+
+        log.info("✅ Access Token 재발급 성공 - memberId: {}", memberId);
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void logout(Long memberId) {
+        refreshTokenService.deleteByMemberId(memberId);
+        log.info("로그아웃 완료 - memberId: {}", memberId);
+    }
+
+    @Transactional
+    public void saveRefreshToken(Long memberId, String refreshToken, long expiresInSeconds) {
+        refreshTokenService.saveOrUpdate(memberId, refreshToken, expiresInSeconds);
     }
 }

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -1,4 +1,4 @@
-package org.sopt.global.service;
+package org.sopt.global.auth.service;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.global.exception.UnauthorizedException;
 import org.sopt.member.domain.Member;
 import org.sopt.member.dto.MemberResponse;
 import org.sopt.member.repository.MemberRepository;
@@ -14,58 +15,32 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final MemberRepository memberRepository;
+    private final JwtService jwtService;
 
-    public MemberResponse login(String authorizationHeader) {
-        if (authorizationHeader == null || authorizationHeader.isBlank()) {
-            throw new IllegalArgumentException("Authorization 헤더가 없습니다.");
+    public MemberResponse loginWithCredentials(String email, String password) {
+        if (email == null || email.isBlank() || password == null || password.isBlank()) {
+            throw new UnauthorizedException("이메일과 비밀번호를 모두 입력해주세요.");
         }
-
-        if (!authorizationHeader.startsWith("Basic ")) {
-            throw new IllegalArgumentException("Basic 인증 형식이 아닙니다.");
-        }
-
-        String token = authorizationHeader.substring("Basic ".length()).trim();
-        String decoded;
-        try {
-            decoded = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Authorization 헤더가 Base64 형식이 아닙니다.");
-        }
-
-        int idx = decoded.indexOf(":");
-        if (idx < 0) {
-            throw new IllegalArgumentException("이메일과 비밀번호 구분자(:)가 없습니다.");
-        }
-
-        String email = decoded.substring(0, idx);
-        String password = decoded.substring(idx + 1);
 
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
         if (member.getPassword() == null || !member.getPassword().equals(password)) {
-            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+            throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 
         return MemberResponse.from(member);
     }
 
-    public MemberResponse loginWithCredentials(String email, String password) {
-        if (email == null || email.isBlank() || password == null ||
-                password.isBlank()) {
-            throw new IllegalArgumentException("이메일과 비밀번호를 모두 입력해주세요.");
+    public MemberResponse authenticateWithJwt(String authorization) {
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new UnauthorizedException("유효하지 않은 인증 정보입니다.");
         }
 
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        String token = authorization.substring("Bearer ".length()).trim();
+        Long memberId = jwtService.verifyAndGetMemberId(token);
 
-        if (member.getPassword() == null || !
-                member.getPassword().equals(password)) {
-            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
-        }
-
-        return MemberResponse.from(member);
-
+        return getMemberById(memberId);
     }
 
     public MemberResponse getMemberById(Long memberId) {

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -33,10 +33,7 @@ public class AuthService {
     private static final long REFRESH_TOKEN_EXPIRES_IN_SECONDS = 1209600;
 
     /* 이메일과 비밀번호로 로그인 */
-    public MemberResponse loginWithCredentials(String email, String password) {
-        if (email == null || email.isBlank() || password == null || password.isBlank()) {
-            throw new UnauthorizedException("이메일과 비밀번호를 모두 입력해주세요.");
-        }
+    public TokenResponse login(String email, String password) {
 
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다."));
@@ -50,17 +47,19 @@ public class AuthService {
             throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 
-        return MemberResponse.from(member);
+        return generateTokens(member);
     }
 
     /* 구글 소셜 로그인 */
     @Transactional
-    public MemberResponse loginWithGoogle(String authorizationCode) {
+    public TokenResponse loginWithGoogle(String authorizationCode) {
         log.info("구글 소셜 로그인 시작");
 
         GoogleTokenResponse tokenResponse = googleOAuthService.getAccessToken(authorizationCode);
 
-        GoogleUserInfoResponse userInfo = googleOAuthService.getUserInfo(tokenResponse.accessToken());
+        GoogleUserInfoResponse userInfo = googleOAuthService.getUserInfo(
+                tokenResponse.accessToken()
+        );
 
         Member member = memberRepository.findByEmail(userInfo.email())
                 .orElseGet(() -> createGoogleMember(userInfo));
@@ -71,7 +70,8 @@ public class AuthService {
         }
 
         log.info("구글 소셜 로그인 성공 - email: {}", member.getEmail());
-        return MemberResponse.from(member);
+
+        return generateTokens(member);
     }
 
     /* 구글 회원 생성 */
@@ -124,6 +124,7 @@ public class AuthService {
 
         String newAccessToken = jwtService.generateAccessToken(member.getId(), member.getEmail());
 
+        // RTR
         String newRefreshToken = jwtService.generateRefreshToken(member.getId());
         refreshTokenService.saveOrUpdate(member.getId(), newRefreshToken, REFRESH_TOKEN_EXPIRES_IN_SECONDS);
 
@@ -141,5 +142,18 @@ public class AuthService {
     @Transactional
     public void saveRefreshToken(Long memberId, String refreshToken, long expiresInSeconds) {
         refreshTokenService.saveOrUpdate(memberId, refreshToken, expiresInSeconds);
+    }
+
+    private TokenResponse generateTokens(Member member) {
+        log.info("🎫 토큰 발급 시작 - memberId: {}", member.getId());
+
+        String accessToken = jwtService.generateAccessToken(member.getId(), member.getEmail());
+        String refreshToken = jwtService.generateRefreshToken(member.getId());
+
+        refreshTokenService.saveOrUpdate(member.getId(), refreshToken, REFRESH_TOKEN_EXPIRES_IN_SECONDS);
+
+        log.info("토큰 발급 완료 - memberId: {}", member.getId());
+
+        return TokenResponse.of(accessToken, refreshToken);
     }
 }

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package org.sopt.global.auth.service;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.member.domain.Member;
 import org.sopt.member.dto.MemberResponse;
@@ -12,67 +13,67 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthService {
 
-  private final MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-  public MemberResponse login(String authorizationHeader) {
-    if (authorizationHeader == null || authorizationHeader.isBlank()) {
-      throw new IllegalArgumentException("Authorization 헤더가 없습니다.");
+    public MemberResponse login(String authorizationHeader) {
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            throw new IllegalArgumentException("Authorization 헤더가 없습니다.");
+        }
+
+        if (!authorizationHeader.startsWith("Basic ")) {
+            throw new IllegalArgumentException("Basic 인증 형식이 아닙니다.");
+        }
+
+        String token = authorizationHeader.substring("Basic ".length()).trim();
+        String decoded;
+        try {
+            decoded = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Authorization 헤더가 Base64 형식이 아닙니다.");
+        }
+
+        int idx = decoded.indexOf(":");
+        if (idx < 0) {
+            throw new IllegalArgumentException("이메일과 비밀번호 구분자(:)가 없습니다.");
+        }
+
+        String email = decoded.substring(0, idx);
+        String password = decoded.substring(idx + 1);
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        if (member.getPassword() == null || !member.getPassword().equals(password)) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        return MemberResponse.from(member);
     }
 
-    if (!authorizationHeader.startsWith("Basic ")) {
-      throw new IllegalArgumentException("Basic 인증 형식이 아닙니다.");
+    public MemberResponse loginWithCredentials(String email, String password) {
+        if (email == null || email.isBlank() || password == null ||
+                password.isBlank()) {
+            throw new IllegalArgumentException("이메일과 비밀번호를 모두 입력해주세요.");
+        }
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        if (member.getPassword() == null || !
+                member.getPassword().equals(password)) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        return MemberResponse.from(member);
+
     }
 
-    String token = authorizationHeader.substring("Basic ".length()).trim();
-    String decoded;
-    try {
-      decoded = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("Authorization 헤더가 Base64 형식이 아닙니다.");
+    public MemberResponse getMemberById(Long memberId) {
+        if (memberId == null) {
+            throw new IllegalArgumentException("로그인되어 있지 않습니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        return MemberResponse.from(member);
     }
-
-    int idx = decoded.indexOf(":");
-    if (idx < 0) {
-      throw new IllegalArgumentException("이메일과 비밀번호 구분자(:)가 없습니다.");
-    }
-
-    String email = decoded.substring(0, idx);
-    String password = decoded.substring(idx + 1);
-
-    Member member = memberRepository.findByEmail(email)
-        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
-
-    if (member.getPassword() == null || !member.getPassword().equals(password)) {
-      throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
-    }
-
-    return MemberResponse.from(member);
-  }
-
-  public MemberResponse loginWithCredentials(String email, String password) {
-    if (email == null || email.isBlank() || password == null ||
-        password.isBlank()) {
-      throw new IllegalArgumentException("이메일과 비밀번호를 모두 입력해주세요.");
-    }
-
-    Member member = memberRepository.findByEmail(email)
-        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
-
-    if (member.getPassword() == null || !
-        member.getPassword().equals(password)) {
-      throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
-    }
-
-    return MemberResponse.from(member);
-
-  }
-
-  public MemberResponse getMemberById(Long memberId) {
-    if (memberId == null) {
-      throw new IllegalArgumentException("로그인되어 있지 않습니다.");
-    }
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
-    return MemberResponse.from(member);
-  }
 }

--- a/src/main/java/org/sopt/global/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/AuthService.java
@@ -62,7 +62,12 @@ public class AuthService {
         );
 
         Member member = memberRepository.findByEmail(userInfo.email())
-                .orElseGet(() -> createGoogleMember(userInfo));
+                .orElseGet(() -> createSocialMember(
+                        userInfo.name(),
+                        userInfo.email(),
+                        userInfo.sub(),
+                        Provider.GOOGLE
+                ));
 
         // 기존 회원인데 다른 Provider인 경우 예외
         if (member.getProvider() != Provider.GOOGLE) {
@@ -74,22 +79,27 @@ public class AuthService {
         return generateTokens(member);
     }
 
-    /* 구글 회원 생성 */
-    private Member createGoogleMember(GoogleUserInfoResponse userInfo) {
-        log.info("구글 신규 회원 생성");
-        log.info("Email: {}", userInfo.email());
-        log.info("Name: {}", userInfo.name());
+    /* 소셜 회원 생성 */
+    private Member createSocialMember(String name, String email, String providerId, Provider provider) {
+        log.info("🆕 {} 신규 회원 생성", provider.name());
+        log.info("📧 Email: {}", email);
+        log.info("👤 Name: {}", name);
+        log.info("🆔 Provider ID: {}", providerId);
 
         Member newMember = Member.createSocialMember(
-                userInfo.name(),
+                name,
                 DEFAULT_BIRTHDATE,
-                userInfo.email(),
+                email,
                 DEFAULT_GENDER,
-                Provider.GOOGLE,
-                userInfo.sub()
+                provider,
+                providerId
         );
 
-        return memberRepository.save(newMember);
+        Member saved = memberRepository.save(newMember);
+        log.info("✅ 회원 저장 완료 - ID: {}, Provider: {}, ProviderId: {}",
+                saved.getId(), saved.getProvider(), saved.getProviderId());
+
+        return saved;
     }
 
     public MemberResponse authenticateWithJwt(String authorization) {

--- a/src/main/java/org/sopt/global/auth/service/GoogleOAuthService.java
+++ b/src/main/java/org/sopt/global/auth/service/GoogleOAuthService.java
@@ -1,0 +1,78 @@
+package org.sopt.global.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.auth.dto.GoogleTokenResponse;
+import org.sopt.global.auth.dto.GoogleUserInfoResponse;
+import org.sopt.global.exception.UnauthorizedException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleOAuthService {
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${oauth.google.client-id}")
+    private String clientId;
+
+    @Value("${oauth.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth.google.redirect-uri}")
+    private String redirectUri;
+
+    private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private static final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+    public GoogleTokenResponse getAccessToken(String authorizationCode) {
+        log.info("구글 Access Token 요청 - code: {}", authorizationCode);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", authorizationCode);
+
+        try {
+            GoogleTokenResponse response = restClient.post()
+                    .uri(GOOGLE_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(GoogleTokenResponse.class);
+
+            log.info("구글 Access Token 발급 성공");
+            return response;
+
+        } catch (Exception e) {
+            log.error("구글 토큰 발급 실패: {}", e.getMessage());
+            throw new UnauthorizedException("구글 토큰 발급에 실패했습니다.");
+        }
+    }
+
+    public GoogleUserInfoResponse getUserInfo(String accessToken) {
+        log.info("구글 사용자 정보 조회");
+
+        try {
+            GoogleUserInfoResponse response = restClient.get()
+                    .uri(GOOGLE_USERINFO_URL)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .body(GoogleUserInfoResponse.class);
+
+            log.info("구글 사용자 정보 조회 성공 - email: {}", response.email());
+            return response;
+
+        } catch (Exception e) {
+            log.error("구글 사용자 정보 조회 실패: {}", e.getMessage());
+            throw new UnauthorizedException("구글 사용자 정보 조회에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/org/sopt/global/auth/service/JwtService.java
+++ b/src/main/java/org/sopt/global/auth/service/JwtService.java
@@ -2,11 +2,16 @@ package org.sopt.global.auth.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import java.time.Instant;
 import java.util.Date;
 
+import org.sopt.global.exception.ExpiredTokenException;
+import org.sopt.global.exception.InvalidTokenException;
+import org.sopt.global.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -40,16 +45,28 @@ public class JwtService {
                 .sign(algorithm);
     }
 
-    public Long verifyAndGetMemberId(String token) {
-        if (token == null || token.isBlank()) {
-            throw new IllegalArgumentException("토큰이 없습니다.");
+    public String extractTokenFromHeader(String authorization) {
+        if (authorization == null || authorization.isBlank()) {
+            throw new UnauthorizedException("Authorization 헤더가 없습니다.");
         }
-        DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
-        String sub = jwt.getSubject();
+
+        if (!authorization.startsWith("Bearer ")) {
+            throw new UnauthorizedException("Bearer 토큰 형식이 아닙니다.");
+        }
+
+        return authorization.substring("Bearer ".length()).trim();
+    }
+
+
+    public Long verifyAndGetMemberId(String token) {
         try {
+            DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+            String sub = jwt.getSubject();
             return Long.parseLong(sub);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
+        } catch (TokenExpiredException e) {
+            throw new ExpiredTokenException("토큰이 만료되었습니다.");
+        } catch (JWTVerificationException e) {
+            throw new InvalidTokenException("유효하지 않은 토큰입니다.", e);
         }
     }
 }

--- a/src/main/java/org/sopt/global/auth/service/JwtService.java
+++ b/src/main/java/org/sopt/global/auth/service/JwtService.java
@@ -88,7 +88,7 @@ public class JwtService {
         } catch (TokenExpiredException e) {
             throw new ExpiredTokenException("토큰이 만료되었습니다.");
         } catch (JWTVerificationException e) {
-            throw new InvalidTokenException("유효하지 않은 토큰입니다.", e);
+            throw new InvalidTokenException("유효하지 않은 토큰입니다.");
         }
     }
 
@@ -103,7 +103,7 @@ public class JwtService {
         } catch (TokenExpiredException e) {
             throw new ExpiredTokenException("토큰이 만료되었습니다.");
         } catch (JWTVerificationException e) {
-            throw new InvalidTokenException("유효하지 않은 토큰입니다.", e);
+            throw new InvalidTokenException("유효하지 않은 토큰입니다.");
         }
     }
 }

--- a/src/main/java/org/sopt/global/auth/service/JwtService.java
+++ b/src/main/java/org/sopt/global/auth/service/JwtService.java
@@ -3,52 +3,54 @@ package org.sopt.global.auth.service;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
+
 import java.time.Instant;
 import java.util.Date;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class JwtService {
 
-  private final Algorithm algorithm;
-  private final long defaultExpiresInSeconds;
+    private final Algorithm algorithm;
+    private final long defaultExpiresInSeconds;
 
-  public JwtService(
-      @Value("${security.jwt.secret}") String secret,
-      @Value("${security.jwt.expires-in-seconds:3600}") long defaultExpiresInSeconds
-  ) {
-    this.algorithm = Algorithm.HMAC256(secret);
-    this.defaultExpiresInSeconds = defaultExpiresInSeconds;
-  }
-
-  public String generateToken(Long memberId, String email) {
-    return generateToken(memberId, email, defaultExpiresInSeconds);
-  }
-
-  public String generateToken(Long memberId, String email, long expiresInSeconds) {
-    Instant now = Instant.now();
-    Instant exp = now.plusSeconds(expiresInSeconds);
-
-    return JWT.create()
-        .withSubject(String.valueOf(memberId))
-        .withClaim("email", email)
-        .withIssuedAt(Date.from(now))
-        .withExpiresAt(Date.from(exp))
-        .sign(algorithm);
-  }
-
-  public Long verifyAndGetMemberId(String token) {
-    if (token == null || token.isBlank()) {
-      throw new IllegalArgumentException("토큰이 없습니다.");
+    public JwtService(
+            @Value("${security.jwt.secret}") String secret,
+            @Value("${security.jwt.expires-in-seconds:3600}") long defaultExpiresInSeconds
+    ) {
+        this.algorithm = Algorithm.HMAC256(secret);
+        this.defaultExpiresInSeconds = defaultExpiresInSeconds;
     }
-    DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
-    String sub = jwt.getSubject();
-    try {
-      return Long.parseLong(sub);
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
+
+    public String generateToken(Long memberId, String email) {
+        return generateToken(memberId, email, defaultExpiresInSeconds);
     }
-  }
+
+    public String generateToken(Long memberId, String email, long expiresInSeconds) {
+        Instant now = Instant.now();
+        Instant exp = now.plusSeconds(expiresInSeconds);
+
+        return JWT.create()
+                .withSubject(String.valueOf(memberId))
+                .withClaim("email", email)
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(exp))
+                .sign(algorithm);
+    }
+
+    public Long verifyAndGetMemberId(String token) {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("토큰이 없습니다.");
+        }
+        DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+        String sub = jwt.getSubject();
+        try {
+            return Long.parseLong(sub);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
+        }
+    }
 }
 

--- a/src/main/java/org/sopt/global/auth/service/JwtService.java
+++ b/src/main/java/org/sopt/global/auth/service/JwtService.java
@@ -1,6 +1,7 @@
 package org.sopt.global.auth.service;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
@@ -20,6 +21,7 @@ public class JwtService {
 
     private final Algorithm algorithm;
     private final long defaultExpiresInSeconds;
+    private static final long REFRESH_TOKEN_EXPIRES_IN_SECONDS = 1209600; // 14일
 
     public JwtService(
             @Value("${security.jwt.secret}") String secret,
@@ -29,20 +31,35 @@ public class JwtService {
         this.defaultExpiresInSeconds = defaultExpiresInSeconds;
     }
 
+    public String generateAccessToken(Long memberId, String email) {
+        return generateToken(memberId, email, defaultExpiresInSeconds);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        return generateToken(memberId, null, REFRESH_TOKEN_EXPIRES_IN_SECONDS);
+    }
+
+    // 기본 만료 시간으로 JWT 토큰 생성
     public String generateToken(Long memberId, String email) {
         return generateToken(memberId, email, defaultExpiresInSeconds);
     }
 
+    // 커스텀 만료 시간으로 JWT 토큰 생성
     public String generateToken(Long memberId, String email, long expiresInSeconds) {
         Instant now = Instant.now();
         Instant exp = now.plusSeconds(expiresInSeconds);
 
-        return JWT.create()
+        JWTCreator.Builder builder = JWT.create()
                 .withSubject(String.valueOf(memberId))
-                .withClaim("email", email)
                 .withIssuedAt(Date.from(now))
-                .withExpiresAt(Date.from(exp))
-                .sign(algorithm);
+                .withExpiresAt(Date.from(exp));
+
+        // email이 있을 때만 추가
+        if (email != null) {
+            builder.withClaim("email", email);
+        }
+
+        return builder.sign(algorithm);
     }
 
     public String extractTokenFromHeader(String authorization) {
@@ -62,7 +79,27 @@ public class JwtService {
         try {
             DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
             String sub = jwt.getSubject();
-            return Long.parseLong(sub);
+
+            try {
+                return Long.parseLong(sub);
+            } catch (NumberFormatException e) {
+                throw new InvalidTokenException("JWT의 회원 정보가 올바르지 않습니다.");
+            }
+        } catch (TokenExpiredException e) {
+            throw new ExpiredTokenException("토큰이 만료되었습니다.");
+        } catch (JWTVerificationException e) {
+            throw new InvalidTokenException("유효하지 않은 토큰입니다.", e);
+        }
+    }
+
+    public String verifyAndGetEmail(String token) {
+        if (token == null || token.isBlank()) {
+            throw new InvalidTokenException("토큰이 없습니다.");
+        }
+
+        try {
+            DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+            return jwt.getClaim("email").asString();
         } catch (TokenExpiredException e) {
             throw new ExpiredTokenException("토큰이 만료되었습니다.");
         } catch (JWTVerificationException e) {

--- a/src/main/java/org/sopt/global/auth/service/JwtService.java
+++ b/src/main/java/org/sopt/global/auth/service/JwtService.java
@@ -1,4 +1,4 @@
-package org.sopt.global.service;
+package org.sopt.global.auth.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;

--- a/src/main/java/org/sopt/global/auth/service/RefreshTokenService.java
+++ b/src/main/java/org/sopt/global/auth/service/RefreshTokenService.java
@@ -1,0 +1,77 @@
+package org.sopt.global.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.auth.domain.RefreshToken;
+import org.sopt.global.auth.repository.RefreshTokenRepository;
+import org.sopt.global.exception.InvalidTokenException;
+import org.sopt.global.exception.UnauthorizedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtService jwtService;
+
+    @Transactional
+    public void saveOrUpdate(Long memberId, String token, long expiresInSeconds) {
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(expiresInSeconds);
+
+        refreshTokenRepository.findByMemberId(memberId)
+                .ifPresentOrElse(
+                        // 기존 토큰 있으면 갱신
+                        existingToken -> {
+                            existingToken.updateToken(token, expiresAt);
+                            log.info("✅ Refresh Token 갱신 - memberId: {}", memberId);
+                        },
+                        // 없으면 새로 생성
+                        () -> {
+                            RefreshToken newToken = RefreshToken.builder()
+                                    .memberId(memberId)
+                                    .token(token)
+                                    .expiresAt(expiresAt)
+                                    .build();
+                            refreshTokenRepository.save(newToken);
+                            log.info("Refresh Token 저장 - memberId: {}", memberId);
+                        }
+                );
+    }
+
+    @Transactional(readOnly = true)
+    public Long validateAndGetMemberId(String token) {
+
+        Long memberId = jwtService.verifyAndGetMemberId(token);
+
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 Refresh Token입니다."));
+
+        if (refreshToken.isExpired()) {
+            throw new InvalidTokenException("만료된 Refresh Token입니다.");
+        }
+
+        if (!refreshToken.getMemberId().equals(memberId)) {
+            throw new InvalidTokenException("토큰 정보가 일치하지 않습니다.");
+        }
+
+        return memberId;
+    }
+
+
+    @Transactional
+    public void deleteByMemberId(Long memberId) {
+        refreshTokenRepository.deleteByMemberId(memberId);
+        log.info("Refresh Token 삭제 - memberId: {}", memberId);
+    }
+
+    @Transactional
+    public void deleteByToken(String token) {
+        refreshTokenRepository.deleteByToken(token);
+        log.info("Refresh Token 삭제 - token: {}...", token.substring(0, 20));
+    }
+}

--- a/src/main/java/org/sopt/global/code/ErrorCode.java
+++ b/src/main/java/org/sopt/global/code/ErrorCode.java
@@ -24,6 +24,9 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
 
+    // 403 Forbidden
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
     // 404 Not Found
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     URL_NOT_FOUND(HttpStatus.NOT_FOUND, "지원하지 않는 URL입니다."),

--- a/src/main/java/org/sopt/global/code/ErrorCode.java
+++ b/src/main/java/org/sopt/global/code/ErrorCode.java
@@ -1,0 +1,39 @@
+package org.sopt.global.code;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorCode {
+
+    // 400 Bad Request
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문(JSON)의 구문이 잘못되었습니다."),
+    INVALID_USER_ID_FORMAT(HttpStatus.BAD_REQUEST, "유저 ID 형식이 올바르지 않습니다."),
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+    MEMBER_AGE_INVALID(HttpStatus.BAD_REQUEST, "회원 나이가 유효하지 않습니다."),
+    DUPLICATE_MEMBER(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
+    DUPLICATE_ARTICLE_TITLE(HttpStatus.BAD_REQUEST, "이미 존재하는 게시글 제목입니다."),
+
+    // 404 Not Found
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    URL_NOT_FOUND(HttpStatus.NOT_FOUND, "지원하지 않는 URL입니다."),
+
+    // 405 Method Not Allowed
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    DATA_STORAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 저장 중 오류가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/org/sopt/global/code/ErrorCode.java
+++ b/src/main/java/org/sopt/global/code/ErrorCode.java
@@ -18,6 +18,12 @@ public enum ErrorCode {
     DUPLICATE_MEMBER(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
     DUPLICATE_ARTICLE_TITLE(HttpStatus.BAD_REQUEST, "이미 존재하는 게시글 제목입니다."),
 
+    // 401 Unauthorized
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+
     // 404 Not Found
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     URL_NOT_FOUND(HttpStatus.NOT_FOUND, "지원하지 않는 URL입니다."),

--- a/src/main/java/org/sopt/global/code/SuccessCode.java
+++ b/src/main/java/org/sopt/global/code/SuccessCode.java
@@ -1,0 +1,33 @@
+package org.sopt.global.code;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessCode {
+
+    // 2xx Success
+    OK(HttpStatus.OK, "요청에 성공했습니다."),
+    CREATED(HttpStatus.CREATED, "✅ 리소스가 성공적으로 생성되었습니다."),
+
+    // Member
+    MEMBER_CREATED(HttpStatus.CREATED, "✅ 회원이 성공적으로 생성되었습니다."),
+    MEMBER_UPDATED(HttpStatus.OK, "회원 정보가 수정되었습니다."),
+    MEMBER_DELETED(HttpStatus.OK, "회원이 삭제되었습니다."),
+
+    // Article
+    ARTICLE_CREATED(HttpStatus.CREATED, "✅ 게시글이 성공적으로 생성되었습니다."),
+    ARTICLE_UPDATED(HttpStatus.OK, "게시글이 수정되었습니다."),
+    ARTICLE_DELETED(HttpStatus.OK, "게시글이 삭제되었습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/org/sopt/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/SecurityConfig.java
@@ -1,0 +1,75 @@
+package org.sopt.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.global.auth.filter.JwtAuthenticationFilter;
+import org.sopt.global.auth.handler.CustomAccessDeniedHandler;
+import org.sopt.global.auth.handler.CustomAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    private static final String[] ALLOWED_PATHS = {
+            // Swagger
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/swagger-config",
+
+            // 인증 API
+            "/api/auth/login",
+            "/api/auth/login/google",
+            "/api/auth/refresh",
+
+            // 회원가입
+            "/api/members"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF 비활성화 (JWT 사용하므로 불필요)
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // 세션 사용 안 함 (Stateless)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 요청별 인가 설정
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(ALLOWED_PATHS).permitAll()
+                        .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+                .exceptionHandling(auth -> auth
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)  // 401
+                        .accessDeniedHandler(customAccessDeniedHandler)  // 403
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/sopt/global/controller/AuthController.java
+++ b/src/main/java/org/sopt/global/controller/AuthController.java
@@ -1,0 +1,135 @@
+package org.sopt.global.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpSession;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.global.dto.ApiResponse;
+import org.sopt.global.service.JwtService;
+import org.sopt.member.dto.MemberResponse;
+import org.sopt.global.service.AuthService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+  private final AuthService authService;
+  private final JwtService jwtService;
+
+  @Operation(summary = "헤더 기반 Basic-Authentication")
+  @PostMapping("/v1/login")
+  public ResponseEntity<ApiResponse<MemberResponse>> login(
+      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
+  ) {
+    log.info(authorization);
+    MemberResponse result = authService.login(authorization);
+    return ResponseEntity.ok(ApiResponse.ok(result));
+  }
+
+  @Operation(summary = "이메일/비밀번호 기반 로그인 (쿠키 발급)")
+  @PostMapping("/v2/login")
+  public ResponseEntity<ApiResponse<MemberResponse>> loginV2(
+      @RequestParam("email") String email,
+      @RequestParam("password") String password
+  ) {
+    MemberResponse result = authService.loginWithCredentials(email, password);
+
+    String credentials = email + ":" + password;
+
+    ResponseCookie cookie = ResponseCookie.from("basic", credentials)
+        .httpOnly(true)
+        .secure(true)
+        .sameSite("Lax")
+        .maxAge(Duration.ofHours(1))
+        .path("/")
+        .build();
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, cookie.toString())
+        .body(ApiResponse.ok(result));
+  }
+
+  @Operation(summary = "쿠키로 로그인 여부 확인")
+  @GetMapping("/v2/me")
+  public ResponseEntity<ApiResponse<MemberResponse>> checkSession(
+      @CookieValue(value = "basic", required = false) String basicCookie
+  ) {
+    if (basicCookie == null) {
+      throw new IllegalArgumentException("로그인 쿠키가 없습니다.");
+    }
+
+    int idx = basicCookie.indexOf(":");
+    if (idx < 0) {
+      throw new IllegalArgumentException("쿠키에 이메일과 비밀번호 구분자(:)가 없습니다.");
+    }
+    String email = basicCookie.substring(0, idx);
+    String password = basicCookie.substring(idx + 1);
+
+    log.info("[v2] 세션 확인, 이메일: {}", email);
+    MemberResponse result = authService.loginWithCredentials(email, password);
+    return ResponseEntity.ok(ApiResponse.ok(result));
+  }
+
+  @Operation(summary = "세션 기반 로그인 (JSESSIONID 발급)")
+  @PostMapping("/v3/login")
+  public ResponseEntity<ApiResponse<MemberResponse>> loginV3(
+      @RequestParam("email") String email,
+      @RequestParam("password") String password,
+      HttpSession session
+  ) {
+    MemberResponse result = authService.loginWithCredentials(email, password);
+    session.setAttribute("LOGIN_MEMBER_ID", result.userId());
+    return ResponseEntity.ok(ApiResponse.ok(result));
+  }
+
+  @Operation(summary = "세션 로그인 여부 확인")
+  @GetMapping("/v3/me")
+  public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV3(
+      HttpSession session
+  ) {
+    Long memberId = (Long) session.getAttribute("LOGIN_MEMBER_ID");
+    MemberResponse result = authService.getMemberById(memberId);
+    return ResponseEntity.ok(ApiResponse.ok(result));
+  }
+
+  @Operation(summary = "JWT 기반 로그인 (토큰 반환)")
+  @PostMapping("/v4/login")
+  public ResponseEntity<ApiResponse<String>> loginV4(
+      @RequestParam("email") String email,
+      @RequestParam("password") String password
+  ) {
+    MemberResponse member = authService.loginWithCredentials(email, password);
+    String token = jwtService.generateToken(member.userId(), member.email());
+    return ResponseEntity.ok(ApiResponse.ok(token));
+  }
+
+  @Operation(summary = "JWT 검증 (Authorization: Bearer)")
+  @GetMapping("/v4/me")
+  public ResponseEntity<ApiResponse<MemberResponse>> checkSessionV4(
+      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
+  ) {
+    String raw = null;
+    if (authorization != null && authorization.startsWith("Bearer ")) {
+      raw = authorization.substring("Bearer ".length()).trim();
+    }
+
+    Long memberId = jwtService.verifyAndGetMemberId(raw);
+    MemberResponse member = authService.getMemberById(memberId);
+    return ResponseEntity.ok(ApiResponse.ok(member));
+  }
+}
+
+
+
+

--- a/src/main/java/org/sopt/global/dto/ApiResponse.java
+++ b/src/main/java/org/sopt/global/dto/ApiResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.global.dto;
 
-import org.springframework.http.HttpStatus;
+import org.sopt.global.code.ErrorCode;
+import org.sopt.global.code.SuccessCode;
 
 public class ApiResponse<T> {
     private final int code; // HTTP 상태 코드
@@ -13,26 +14,30 @@ public class ApiResponse<T> {
         this.data = data;
     }
 
-    public static <T> ApiResponse<T> ok(int code, String message, T data) {
-        return new ApiResponse<>(code, message, data);
+    public static <T> ApiResponse<T> of(SuccessCode successCode, T data) {
+        return new ApiResponse<>(successCode.getStatusCode(), successCode.getMessage(), data);
     }
 
-    public static <T> ApiResponse<T> ok(int code, String message) {
-        return new ApiResponse<>(code, message, null);
+    public static <T> ApiResponse<T> of(SuccessCode successCode) {
+        return new ApiResponse<>(successCode.getStatusCode(), successCode.getMessage(), null);
     }
 
     // 200 OK
     public static <T> ApiResponse<T> ok(T data) {
-        return new ApiResponse<>(HttpStatus.OK.value(), "요청에 성공했습니다.", data);
+        return of(SuccessCode.OK, data);
     }
 
     // 201 Created
     public static <T> ApiResponse<T> created(T data) {
-        return new ApiResponse<>(HttpStatus.CREATED.value(), "✅ 리소스가 성공적으로 생성되었습니다.", data);
+        return of(SuccessCode.CREATED, data);
     }
 
-    public static <T> ApiResponse<T> error(int code, String message) {
-        return new ApiResponse<>(code, message, null);
+    public static <T> ApiResponse<T> of(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getStatusCode(), errorCode.getMessage(), null);
+    }
+
+    public static <T> ApiResponse<T> of(ErrorCode errorCode, String customMessage) {
+        return new ApiResponse<>(errorCode.getStatusCode(), customMessage, null);
     }
 
     public int getCode() { return code; }

--- a/src/main/java/org/sopt/global/exception/BusinessException.java
+++ b/src/main/java/org/sopt/global/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package org.sopt.global.exception;
+
+import org.sopt.global.code.ErrorCode;
+
+public abstract class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    protected BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/org/sopt/global/exception/DataStorageException.java
+++ b/src/main/java/org/sopt/global/exception/DataStorageException.java
@@ -1,7 +1,9 @@
 package org.sopt.global.exception;
 
-public class DataStorageException extends RuntimeException {
-    public DataStorageException(String message, Throwable cause) {
-        super(message, cause);
+import org.sopt.global.code.ErrorCode;
+
+public class DataStorageException extends BusinessException {
+    public DataStorageException(String message) {
+        super(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/org/sopt/global/exception/EntityNotFoundException.java
+++ b/src/main/java/org/sopt/global/exception/EntityNotFoundException.java
@@ -1,7 +1,9 @@
 package org.sopt.global.exception;
 
-public class EntityNotFoundException extends RuntimeException {
+import org.sopt.global.code.ErrorCode;
+
+public class EntityNotFoundException extends BusinessException {
     public EntityNotFoundException(String message) {
-        super(message);
+        super(ErrorCode.ENTITY_NOT_FOUND);
     }
 }

--- a/src/main/java/org/sopt/global/exception/ExpiredTokenException.java
+++ b/src/main/java/org/sopt/global/exception/ExpiredTokenException.java
@@ -1,11 +1,9 @@
 package org.sopt.global.exception;
 
-public class ExpiredTokenException extends RuntimeException {
-    public ExpiredTokenException(String message) {
-        super(message);
-    }
+import org.sopt.global.code.ErrorCode;
 
-    public ExpiredTokenException(String message, Throwable cause) {
-        super(message, cause);
+public class ExpiredTokenException extends BusinessException {
+    public ExpiredTokenException(String message) {
+        super(ErrorCode.EXPIRED_TOKEN);
     }
 }

--- a/src/main/java/org/sopt/global/exception/ExpiredTokenException.java
+++ b/src/main/java/org/sopt/global/exception/ExpiredTokenException.java
@@ -1,0 +1,11 @@
+package org.sopt.global.exception;
+
+public class ExpiredTokenException extends RuntimeException {
+    public ExpiredTokenException(String message) {
+        super(message);
+    }
+
+    public ExpiredTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
@@ -86,6 +86,30 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.of(ErrorCode.INVALID_INPUT_VALUE, message));
     }
 
+    // 401 Unauthorized - 인증 실패
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<?>> handleUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity
+                .status(ErrorCode.UNAUTHORIZED.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.UNAUTHORIZED, e.getMessage()));
+    }
+
+    // 401 Unauthorized - 유효하지 않은 토큰
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ApiResponse<?>> handleInvalidTokenException(InvalidTokenException e) {
+        return ResponseEntity
+                .status(ErrorCode.INVALID_TOKEN.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.INVALID_TOKEN, e.getMessage()));
+    }
+
+    // 401 Unauthorized - 만료된 토큰
+    @ExceptionHandler(ExpiredTokenException.class)
+    public ResponseEntity<ApiResponse<?>> handleExpiredTokenException(ExpiredTokenException e) {
+        return ResponseEntity
+                .status(ErrorCode.EXPIRED_TOKEN.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.EXPIRED_TOKEN, e.getMessage()));
+    }
+
     // 404 Not Found - URL 없음
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ApiResponse<?>> handleNoHandlerFound(NoHandlerFoundException e) {
@@ -110,7 +134,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.of(ErrorCode.METHOD_NOT_ALLOWED));
     }
 
-    // 500 Internal Server Error
+    // 500 Internal Server Error - 데이터 저장 실패
     @ExceptionHandler(DataStorageException.class)
     public ResponseEntity<ApiResponse<?>> handleDataStorageException(DataStorageException e) {
         System.err.println("DATA_STORAGE_ERROR: " + e.getMessage());
@@ -120,7 +144,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.of(ErrorCode.DATA_STORAGE_ERROR));
     }
 
-    // 500 Internal Server Error
+    // 500 Internal Server Error - 기타 예외
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         System.err.println("INTERNAL_SERVER_ERROR: " + e.getMessage());

--- a/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,10 @@
 package org.sopt.global.exception;
 
 import org.sopt.article.exception.DuplicateArticleTitleException;
+import org.sopt.global.code.ErrorCode;
 import org.sopt.global.dto.ApiResponse;
 import org.sopt.member.exception.DuplicateMemberException;
 import org.sopt.member.exception.MemberAgeException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -18,78 +18,116 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 400 Bad Request (비즈니스 로직 예외)
-    @ExceptionHandler({
-            MethodArgumentTypeMismatchException.class,
-            MemberAgeException.class,
-            DuplicateMemberException.class,
-            DuplicateArticleTitleException.class,
-            IllegalArgumentException.class,
-            HttpMessageNotReadableException.class
-    })
+    // 400 Bad Request - JSON 파싱 실패
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        Throwable cause = e.getCause();
 
-    public ResponseEntity<ApiResponse<?>> handleBadRequestException(Exception e) {
-        String message;
-        if (e instanceof HttpMessageNotReadableException) { // JSON 파싱 실패
-            Throwable cause = e.getCause(); // 원인 확인
-
-            if (cause != null && cause.getCause() instanceof InvalidFormatException) { // enum 파싱 오류
-                message = cause.getCause().getMessage();
-            } else {
-                message = "요청 본문(JSON)의 구문이 잘못되었습니다.";
-            }
-        } else if (e instanceof MethodArgumentTypeMismatchException) {
-            message = "유저 ID 형식이 올바르지 않습니다.";
-        } else if (e instanceof IllegalArgumentException) { // Validator가 던진 예외
-            message = e.getMessage();
-        } else { // 비즈니스 로직 예외
-            message = e.getMessage();
+        if (cause != null && cause.getCause() instanceof InvalidFormatException) {
+            // enum 파싱 오류인 경우 원인 메시지 사용
+            String message = cause.getCause().getMessage();
+            return ResponseEntity
+                    .status(ErrorCode.INVALID_REQUEST_BODY.getHttpStatus())
+                    .body(ApiResponse.of(ErrorCode.INVALID_REQUEST_BODY, message));
         }
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST) // 400
-                .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message));
+                .status(ErrorCode.INVALID_REQUEST_BODY.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.INVALID_REQUEST_BODY));
     }
 
+    // 400 Bad Request - 타입 미스매치
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity
+                .status(ErrorCode.INVALID_USER_ID_FORMAT.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.INVALID_USER_ID_FORMAT));
+    }
+
+    // 400 Bad Request - 회원 나이 예외
+    @ExceptionHandler(MemberAgeException.class)
+    public ResponseEntity<ApiResponse<?>> handleMemberAgeException(MemberAgeException e) {
+        return ResponseEntity
+                .status(ErrorCode.MEMBER_AGE_INVALID.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.MEMBER_AGE_INVALID, e.getMessage()));
+    }
+
+    // 400 Bad Request - 중복 회원
+    @ExceptionHandler(DuplicateMemberException.class)
+    public ResponseEntity<ApiResponse<?>> handleDuplicateMemberException(DuplicateMemberException e) {
+        return ResponseEntity
+                .status(ErrorCode.DUPLICATE_MEMBER.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.DUPLICATE_MEMBER, e.getMessage()));
+    }
+
+    // 400 Bad Request - 중복 게시글 제목
+    @ExceptionHandler(DuplicateArticleTitleException.class)
+    public ResponseEntity<ApiResponse<?>> handleDuplicateArticleTitleException(DuplicateArticleTitleException e) {
+        return ResponseEntity
+                .status(ErrorCode.DUPLICATE_ARTICLE_TITLE.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.DUPLICATE_ARTICLE_TITLE, e.getMessage()));
+    }
+
+    // 400 Bad Request - IllegalArgumentException
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity
+                .status(ErrorCode.INVALID_ARGUMENT.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.INVALID_ARGUMENT, e.getMessage()));
+    }
+
+    // 400 Bad Request - Validation 실패
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
         String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message));
+                .status(ErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.INVALID_INPUT_VALUE, message));
     }
 
+    // 404 Not Found - URL 없음
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ApiResponse<?>> handleNoHandlerFound(NoHandlerFoundException e) {
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND) // 404
-                .body(ApiResponse.error(HttpStatus.NOT_FOUND.value(), "지원하지 않는 URL입니다."));
+                .status(ErrorCode.URL_NOT_FOUND.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.URL_NOT_FOUND));
     }
 
-    // 404 Not Found
+    // 404 Not Found - 엔티티 없음
     @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ApiResponse<?>> handleNotFoundException(EntityNotFoundException e) {
+    public ResponseEntity<ApiResponse<?>> handleEntityNotFoundException(EntityNotFoundException e) {
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND) // 404
-                .body(ApiResponse.error(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+                .status(ErrorCode.ENTITY_NOT_FOUND.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.ENTITY_NOT_FOUND, e.getMessage()));
     }
 
     // 405 Method Not Allowed
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
         return ResponseEntity
-                .status(HttpStatus.METHOD_NOT_ALLOWED) // 405
-                .body(ApiResponse.error(HttpStatus.METHOD_NOT_ALLOWED.value(), "잘못된 HTTP method 요청입니다."));
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.METHOD_NOT_ALLOWED));
     }
 
     // 500 Internal Server Error
-    @ExceptionHandler({DataStorageException.class, Exception.class})
-    public ResponseEntity<ApiResponse<?>> handleInternalException(Exception e) {
-        System.err.println("INTERNAL_SERVER_ERROR: " + e.getMessage());
+    @ExceptionHandler(DataStorageException.class)
+    public ResponseEntity<ApiResponse<?>> handleDataStorageException(DataStorageException e) {
+        System.err.println("DATA_STORAGE_ERROR: " + e.getMessage());
 
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR) // 500
-                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."));
+                .status(ErrorCode.DATA_STORAGE_ERROR.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.DATA_STORAGE_ERROR));
+    }
+
+    // 500 Internal Server Error
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        System.err.println("INTERNAL_SERVER_ERROR: " + e.getMessage());
+        e.printStackTrace();
+
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,8 @@
 package org.sopt.global.exception;
 
-import org.sopt.article.exception.DuplicateArticleTitleException;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.global.code.ErrorCode;
 import org.sopt.global.dto.ApiResponse;
-import org.sopt.member.exception.DuplicateMemberException;
-import org.sopt.member.exception.MemberAgeException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -14,144 +12,110 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 400 Bad Request - JSON 파싱 실패
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
-        Throwable cause = e.getCause();
+    // 비즈니스 예외 처리 (BusinessException 상속한 모든 예외)
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("❌ BusinessException: {}", e.getMessage());
 
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatusCode())
+                .body(ApiResponse.of(errorCode));
+    }
+
+    // @Valid 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(
+            MethodArgumentNotValidException e
+    ) {
+        log.warn("❌ Validation Error: {}", e.getMessage());
+
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.of(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    // JSON 파싱 실패
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException e
+    ) {
+        log.warn("❌ JSON Parsing Error: {}", e.getMessage());
+
+        Throwable cause = e.getCause();
         if (cause != null && cause.getCause() instanceof InvalidFormatException) {
-            // enum 파싱 오류인 경우 원인 메시지 사용
             String message = cause.getCause().getMessage();
             return ResponseEntity
-                    .status(ErrorCode.INVALID_REQUEST_BODY.getHttpStatus())
+                    .badRequest()
                     .body(ApiResponse.of(ErrorCode.INVALID_REQUEST_BODY, message));
         }
 
         return ResponseEntity
-                .status(ErrorCode.INVALID_REQUEST_BODY.getHttpStatus())
+                .badRequest()
                 .body(ApiResponse.of(ErrorCode.INVALID_REQUEST_BODY));
     }
 
-    // 400 Bad Request - 타입 미스매치
+    // 타입 미스매치
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ApiResponse<?>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException e
+    ) {
+        log.warn("❌ Type Mismatch: {}", e.getMessage());
+
         return ResponseEntity
-                .status(ErrorCode.INVALID_USER_ID_FORMAT.getHttpStatus())
+                .badRequest()
                 .body(ApiResponse.of(ErrorCode.INVALID_USER_ID_FORMAT));
     }
 
-    // 400 Bad Request - 회원 나이 예외
-    @ExceptionHandler(MemberAgeException.class)
-    public ResponseEntity<ApiResponse<?>> handleMemberAgeException(MemberAgeException e) {
-        return ResponseEntity
-                .status(ErrorCode.MEMBER_AGE_INVALID.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.MEMBER_AGE_INVALID, e.getMessage()));
-    }
-
-    // 400 Bad Request - 중복 회원
-    @ExceptionHandler(DuplicateMemberException.class)
-    public ResponseEntity<ApiResponse<?>> handleDuplicateMemberException(DuplicateMemberException e) {
-        return ResponseEntity
-                .status(ErrorCode.DUPLICATE_MEMBER.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.DUPLICATE_MEMBER, e.getMessage()));
-    }
-
-    // 400 Bad Request - 중복 게시글 제목
-    @ExceptionHandler(DuplicateArticleTitleException.class)
-    public ResponseEntity<ApiResponse<?>> handleDuplicateArticleTitleException(DuplicateArticleTitleException e) {
-        return ResponseEntity
-                .status(ErrorCode.DUPLICATE_ARTICLE_TITLE.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.DUPLICATE_ARTICLE_TITLE, e.getMessage()));
-    }
-
-    // 400 Bad Request - IllegalArgumentException
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ResponseEntity
-                .status(ErrorCode.INVALID_ARGUMENT.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.INVALID_ARGUMENT, e.getMessage()));
-    }
-
-    // 400 Bad Request - Validation 실패
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-
-        return ResponseEntity
-                .status(ErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.INVALID_INPUT_VALUE, message));
-    }
-
-    // 401 Unauthorized - 인증 실패
-    @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<ApiResponse<?>> handleUnauthorizedException(UnauthorizedException e) {
-        return ResponseEntity
-                .status(ErrorCode.UNAUTHORIZED.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.UNAUTHORIZED, e.getMessage()));
-    }
-
-    // 401 Unauthorized - 유효하지 않은 토큰
-    @ExceptionHandler(InvalidTokenException.class)
-    public ResponseEntity<ApiResponse<?>> handleInvalidTokenException(InvalidTokenException e) {
-        return ResponseEntity
-                .status(ErrorCode.INVALID_TOKEN.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.INVALID_TOKEN, e.getMessage()));
-    }
-
-    // 401 Unauthorized - 만료된 토큰
-    @ExceptionHandler(ExpiredTokenException.class)
-    public ResponseEntity<ApiResponse<?>> handleExpiredTokenException(ExpiredTokenException e) {
-        return ResponseEntity
-                .status(ErrorCode.EXPIRED_TOKEN.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.EXPIRED_TOKEN, e.getMessage()));
-    }
-
-    // 404 Not Found - URL 없음
+    // URL 없음 (404)
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ApiResponse<?>> handleNoHandlerFound(NoHandlerFoundException e) {
+    public ResponseEntity<ApiResponse<Void>> handleNoHandlerFound(
+            NoHandlerFoundException e
+    ) {
+        log.warn("❌ URL Not Found: {}", e.getRequestURL());
+
         return ResponseEntity
                 .status(ErrorCode.URL_NOT_FOUND.getHttpStatus())
                 .body(ApiResponse.of(ErrorCode.URL_NOT_FOUND));
     }
 
-    // 404 Not Found - 엔티티 없음
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ApiResponse<?>> handleEntityNotFoundException(EntityNotFoundException e) {
-        return ResponseEntity
-                .status(ErrorCode.ENTITY_NOT_FOUND.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.ENTITY_NOT_FOUND, e.getMessage()));
-    }
-
-    // 405 Method Not Allowed
+    // HTTP Method 불일치 (405)
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ApiResponse<?>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(
+            HttpRequestMethodNotSupportedException e
+    ) {
+        log.warn("❌ Method Not Allowed: {}", e.getMethod());
+
         return ResponseEntity
                 .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
                 .body(ApiResponse.of(ErrorCode.METHOD_NOT_ALLOWED));
     }
 
-    // 500 Internal Server Error - 데이터 저장 실패
-    @ExceptionHandler(DataStorageException.class)
-    public ResponseEntity<ApiResponse<?>> handleDataStorageException(DataStorageException e) {
-        System.err.println("DATA_STORAGE_ERROR: " + e.getMessage());
+    // IllegalArgumentException (400)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(
+            IllegalArgumentException e
+    ) {
+        log.warn("❌ Illegal Argument: {}", e.getMessage());
 
         return ResponseEntity
-                .status(ErrorCode.DATA_STORAGE_ERROR.getHttpStatus())
-                .body(ApiResponse.of(ErrorCode.DATA_STORAGE_ERROR));
+                .badRequest()
+                .body(ApiResponse.of(ErrorCode.INVALID_ARGUMENT, e.getMessage()));
     }
 
-    // 500 Internal Server Error - 기타 예외
+    // 그 외 모든 예외 (500)
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
-        System.err.println("INTERNAL_SERVER_ERROR: " + e.getMessage());
-        e.printStackTrace();
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("❌ Unexpected Error: ", e);
 
         return ResponseEntity
-                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .internalServerError()
                 .body(ApiResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/org/sopt/global/exception/InvalidFormatException.java
+++ b/src/main/java/org/sopt/global/exception/InvalidFormatException.java
@@ -1,12 +1,9 @@
 package org.sopt.global.exception;
 
-public class InvalidFormatException extends IllegalArgumentException {
+import org.sopt.global.code.ErrorCode;
 
+public class InvalidFormatException extends BusinessException {
     public InvalidFormatException(String message) {
-        super(message);
-    }
-
-    public InvalidFormatException(String message, Throwable cause) {
-        super(message, cause);
+        super(ErrorCode.INVALID_ARGUMENT);
     }
 }

--- a/src/main/java/org/sopt/global/exception/InvalidTokenException.java
+++ b/src/main/java/org/sopt/global/exception/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package org.sopt.global.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/sopt/global/exception/InvalidTokenException.java
+++ b/src/main/java/org/sopt/global/exception/InvalidTokenException.java
@@ -1,11 +1,9 @@
 package org.sopt.global.exception;
 
-public class InvalidTokenException extends RuntimeException {
-    public InvalidTokenException(String message) {
-        super(message);
-    }
+import org.sopt.global.code.ErrorCode;
 
-    public InvalidTokenException(String message, Throwable cause) {
-        super(message, cause);
+public class InvalidTokenException extends BusinessException {
+    public InvalidTokenException(String message) {
+        super(ErrorCode.INVALID_TOKEN);
     }
 }

--- a/src/main/java/org/sopt/global/exception/UnauthorizedException.java
+++ b/src/main/java/org/sopt/global/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package org.sopt.global.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/sopt/global/exception/UnauthorizedException.java
+++ b/src/main/java/org/sopt/global/exception/UnauthorizedException.java
@@ -1,7 +1,10 @@
 package org.sopt.global.exception;
 
-public class UnauthorizedException extends RuntimeException {
+import org.sopt.global.code.ErrorCode;
+
+public class UnauthorizedException extends BusinessException {
     public UnauthorizedException(String message) {
-        super(message);
+        super(ErrorCode.UNAUTHORIZED);
     }
 }
+

--- a/src/main/java/org/sopt/global/service/AuthService.java
+++ b/src/main/java/org/sopt/global/service/AuthService.java
@@ -1,0 +1,78 @@
+package org.sopt.global.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.sopt.member.domain.Member;
+import org.sopt.member.dto.MemberResponse;
+import org.sopt.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final MemberRepository memberRepository;
+
+  public MemberResponse login(String authorizationHeader) {
+    if (authorizationHeader == null || authorizationHeader.isBlank()) {
+      throw new IllegalArgumentException("Authorization 헤더가 없습니다.");
+    }
+
+    if (!authorizationHeader.startsWith("Basic ")) {
+      throw new IllegalArgumentException("Basic 인증 형식이 아닙니다.");
+    }
+
+    String token = authorizationHeader.substring("Basic ".length()).trim();
+    String decoded;
+    try {
+      decoded = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Authorization 헤더가 Base64 형식이 아닙니다.");
+    }
+
+    int idx = decoded.indexOf(":");
+    if (idx < 0) {
+      throw new IllegalArgumentException("이메일과 비밀번호 구분자(:)가 없습니다.");
+    }
+
+    String email = decoded.substring(0, idx);
+    String password = decoded.substring(idx + 1);
+
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+    if (member.getPassword() == null || !member.getPassword().equals(password)) {
+      throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    return MemberResponse.from(member);
+  }
+
+  public MemberResponse loginWithCredentials(String email, String password) {
+    if (email == null || email.isBlank() || password == null ||
+        password.isBlank()) {
+      throw new IllegalArgumentException("이메일과 비밀번호를 모두 입력해주세요.");
+    }
+
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+    if (member.getPassword() == null || !
+        member.getPassword().equals(password)) {
+      throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    return MemberResponse.from(member);
+
+  }
+
+  public MemberResponse getMemberById(Long memberId) {
+    if (memberId == null) {
+      throw new IllegalArgumentException("로그인되어 있지 않습니다.");
+    }
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+    return MemberResponse.from(member);
+  }
+}

--- a/src/main/java/org/sopt/global/service/JwtService.java
+++ b/src/main/java/org/sopt/global/service/JwtService.java
@@ -1,0 +1,54 @@
+package org.sopt.global.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.time.Instant;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+
+  private final Algorithm algorithm;
+  private final long defaultExpiresInSeconds;
+
+  public JwtService(
+      @Value("${security.jwt.secret}") String secret,
+      @Value("${security.jwt.expires-in-seconds:3600}") long defaultExpiresInSeconds
+  ) {
+    this.algorithm = Algorithm.HMAC256(secret);
+    this.defaultExpiresInSeconds = defaultExpiresInSeconds;
+  }
+
+  public String generateToken(Long memberId, String email) {
+    return generateToken(memberId, email, defaultExpiresInSeconds);
+  }
+
+  public String generateToken(Long memberId, String email, long expiresInSeconds) {
+    Instant now = Instant.now();
+    Instant exp = now.plusSeconds(expiresInSeconds);
+
+    return JWT.create()
+        .withSubject(String.valueOf(memberId))
+        .withClaim("email", email)
+        .withIssuedAt(Date.from(now))
+        .withExpiresAt(Date.from(exp))
+        .sign(algorithm);
+  }
+
+  public Long verifyAndGetMemberId(String token) {
+    if (token == null || token.isBlank()) {
+      throw new IllegalArgumentException("토큰이 없습니다.");
+    }
+    DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+    String sub = jwt.getSubject();
+    try {
+      return Long.parseLong(sub);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
+    }
+  }
+}
+

--- a/src/main/java/org/sopt/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.sopt.member.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.sopt.member.domain.Member;
 import org.sopt.global.dto.ApiResponse;
@@ -14,8 +15,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Members", description = "회원 API")
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/members")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/org/sopt/member/domain/Member.java
+++ b/src/main/java/org/sopt/member/domain/Member.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.article.domain.Article;
@@ -27,7 +28,7 @@ public class Member {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     @Column(nullable = false)
@@ -40,23 +41,64 @@ public class Member {
     @Column(nullable = false)
     private Gender gender;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Provider provider;
+
+    @Column(nullable = true)
+    private String providerId; // 소셜 로그인 고유 ID
+
     @OneToMany(mappedBy = "member")
     private List<Article> articles = new ArrayList<>();
 
-    public Member(String name, String password, LocalDate birthdate, String email, Gender gender) {
-        this(null, name, password, birthdate, email, gender);
-    }
-
-    public Member(Long id, String name, String password, LocalDate birthdate, String email, Gender gender) {
+    @Builder
+    private Member(Long id, String name, String password, LocalDate birthdate,
+                   String email, Gender gender, Provider provider, String providerId) {
         this.id = id;
         this.name = name;
+        this.password = password;
         this.birthdate = birthdate;
         this.email = email;
         this.gender = gender;
-        this.password = password;
+        this.provider = provider != null ? provider : Provider.LOCAL;
+        this.providerId = providerId;
     }
 
     public int getAge() {
         return Period.between(this.birthdate, LocalDate.now()).getYears();
+    }
+
+    public boolean isLocalMember() {
+        return this.provider == Provider.LOCAL;
+    }
+
+    public boolean isSocialMember() {
+        return this.provider != Provider.LOCAL;
+    }
+
+    // 일반 회원가입
+    public static Member createLocalMember(String name, String password, LocalDate birthdate,
+                                           String email, Gender gender) {
+        return Member.builder()
+                .name(name)
+                .password(password)
+                .birthdate(birthdate)
+                .email(email)
+                .gender(gender)
+                .provider(Provider.LOCAL)
+                .build();
+    }
+
+    // 소셜 로그인
+    public static Member createSocialMember(String name, LocalDate birthdate, String email,
+                                            Gender gender, Provider provider, String providerId) {
+        return Member.builder()
+                .name(name)
+                .birthdate(birthdate)
+                .email(email)
+                .gender(gender)
+                .provider(provider)
+                .providerId(providerId)
+                .build();
     }
 }

--- a/src/main/java/org/sopt/member/domain/Member.java
+++ b/src/main/java/org/sopt/member/domain/Member.java
@@ -28,6 +28,9 @@ public class Member {
     private String name;
 
     @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
     private LocalDate birthdate;
 
     @Column(nullable = false, unique = true)
@@ -40,16 +43,17 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private List<Article> articles = new ArrayList<>();
 
-    public Member(String name, LocalDate birthdate, String email, Gender gender) {
-        this(null, name, birthdate, email, gender);
+    public Member(String name, String password, LocalDate birthdate, String email, Gender gender) {
+        this(null, name, password, birthdate, email, gender);
     }
 
-    public Member(Long id, String name, LocalDate birthdate, String email, Gender gender) {
+    public Member(Long id, String name, String password, LocalDate birthdate, String email, Gender gender) {
         this.id = id;
         this.name = name;
         this.birthdate = birthdate;
         this.email = email;
         this.gender = gender;
+        this.password = password;
     }
 
     public int getAge() {

--- a/src/main/java/org/sopt/member/domain/Provider.java
+++ b/src/main/java/org/sopt/member/domain/Provider.java
@@ -1,0 +1,8 @@
+package org.sopt.member.domain;
+
+public enum Provider {
+    LOCAL,      // 일반 회원가입
+    GOOGLE,     // 구글 소셜 로그인
+    KAKAO,      // 카카오 소셜 로그인 (향후 추가)
+    NAVER       // 네이버 소셜 로그인 (향후 추가)
+}

--- a/src/main/java/org/sopt/member/dto/MemberCreateRequest.java
+++ b/src/main/java/org/sopt/member/dto/MemberCreateRequest.java
@@ -16,6 +16,9 @@ public record MemberCreateRequest(
         @NotNull(message = "생년월일은 필수 입력 항목입니다.")
         LocalDate birthdate,
 
+        @NotNull(message = "비밀번호는 필수 입력 항목입니다.")
+        String password,
+
         @NotBlank(message = "이메일은 필수 입력 항목입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         String email,

--- a/src/main/java/org/sopt/member/dto/MemberResponse.java
+++ b/src/main/java/org/sopt/member/dto/MemberResponse.java
@@ -21,4 +21,7 @@ public record MemberResponse(
                 member.getGender()
         );
     }
+    public static MemberResponse of(Long id, String name, LocalDate birthDate, String email, Gender gender) {
+        return new MemberResponse(id, name, birthDate,email, gender);
+    }
 }

--- a/src/main/java/org/sopt/member/exception/DuplicateMemberException.java
+++ b/src/main/java/org/sopt/member/exception/DuplicateMemberException.java
@@ -1,7 +1,14 @@
 package org.sopt.member.exception;
 
-public class DuplicateMemberException extends IllegalStateException {
+import org.sopt.global.code.ErrorCode;
+import org.sopt.global.exception.BusinessException;
+
+public class DuplicateMemberException extends BusinessException {
     public DuplicateMemberException(String message) {
-        super(message);
+        super(ErrorCode.DUPLICATE_MEMBER);
+    }
+
+    public DuplicateMemberException(ErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/org/sopt/member/exception/MemberAgeException.java
+++ b/src/main/java/org/sopt/member/exception/MemberAgeException.java
@@ -1,7 +1,14 @@
 package org.sopt.member.exception;
 
-public class MemberAgeException extends IllegalStateException {
+import org.sopt.global.code.ErrorCode;
+import org.sopt.global.exception.BusinessException;
+
+public class MemberAgeException extends BusinessException {
     public MemberAgeException(String message) {
-        super(message);
+        super(ErrorCode.MEMBER_AGE_INVALID);
+    }
+
+    public MemberAgeException(ErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/org/sopt/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/sopt/member/service/MemberServiceImpl.java
@@ -21,7 +21,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Member join(MemberCreateRequest request) {
-        Member member = new Member(
+        Member member = Member.createLocalMember(
                 request.name(),
                 request.password(),
                 request.birthdate(),

--- a/src/main/java/org/sopt/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/sopt/member/service/MemberServiceImpl.java
@@ -23,6 +23,7 @@ public class MemberServiceImpl implements MemberService {
     public Member join(MemberCreateRequest request) {
         Member member = new Member(
                 request.name(),
+                request.password(),
                 request.birthdate(),
                 request.email(),
                 request.gender()


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 인증/인가 흐름에 대해 복습
- [x] OAuth2.0 기반 소셜로그인 프로세스 정리

### 선택과제
- [x] JWT 발급 및 검증 로직 구현
- [x] 인증, 인가 관련 로직 추가 구현

---

### **구현한 내용에 대해서 설명해주세요**
1. Spring Security + JWT 인증 아키텍처 구축
- SecurityConfig 설정
  - Session: SessionCreationPolicy.STATELESS (JWT 사용을 위해 세션 비활성화)
  - CSRF: 비활성화 (Stateless API이므로 불필요)
  - Authorize:
    - permitAll: 회원가입, 로그인, 토큰 재발급, 게시글 조회(GET), Swagger
    - authenticated: 그 외 모든 요청 (특히 회원 탈퇴, 게시글 작성 등)
- 인증 필터 (JwtAuthenticationFilter)
  - OncePerRequestFilter를 상속받아 매 요청마다 동작
  - Authorization 헤더에서 Access Token 추출 및 검증
  - 검증 성공 시 SecurityContextHolder에 Authentication 객체 저장 -> 이후 Controller에서 @AuthenticationPrincipal로 사용 가능 
- 예외 처리 핸들러
  - CustomAuthenticationEntryPoint: 인증되지 않은 사용자 접근 시 401 응답
  - CustomAccessDeniedHandler: 권한이 없는 사용자 접근 시 403 응답


#### 구현된 API
```
POST /api/auth/login              # 일반 로그인 (AT + RT 발급)
POST  /api/auth/login/google       # 구글 소셜 로그인 (AT + RT 발급)
POST  /api/auth/refresh            # Access Token 재발급 (RTR 적용)
POST  /api/auth/logout             # 로그아웃 (RT 삭제)
GET   /api/auth/me                 # 내 정보 조회 (AT 검증)
```

### 2. 구글 OAuth 2.0 소셜 로그인
#### 구현 플로우
```
1. 프론트엔드 → 구글 로그인 페이지
2. 사용자 로그인 및 권한 동의
3. 구글 → Authorization Code 발급
4. 백엔드 → Authorization Code로 Access Token 요청
5. 백엔드 → Access Token으로 사용자 정보 조회
6. 백엔드 → 회원 조회/생성 후 JWT 발급
```

#### 주요 구현
- `GoogleOAuthService`: 구글 API 통신 담당 (RestClient 사용)
- `Member` 엔티티에 `provider`, `providerId` 필드 추가
- 소셜 로그인 회원은 자동 생성 (생년월일, 성별은 기본값)
- 일반 회원과 소셜 회원 구분하여 로그인 제한

### 3. JWT 인증 시스템 구현
- Access Token: 1시간, Refresh Token: 14일
- RTR (Refresh Token Rotation) 적용
- 로그아웃: Refresh Token DB에서 삭제 처리

### 4. 전역 예외 처리 체계 개선 (GlobalExceptionHandler)
- SuccessCode / ErrorCode Enum 도입
- 비즈니스 예외 및 인증 예외를 통합 관리하여 일관된 JSON 응답 포맷 유지
---

### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**
### Refresh Token을 DB 저장 여부
- JWT의 장점은 서버에 저장하지 않는 것인데, RT를 DB에 저장하면 성능 저하가 아닌지 고민

**결론:**
- Access Token은 여전히 Stateless (DB 조회 없음)
- Refresh Token만 DB에 저장하여 **무효화 가능**하게 함 (로그아웃, 보안 이슈 시)
- 갱신은 자주 일어나지 않아 성능 영향 미미
- 보안성 >> 성능 (소폭)
<br>

### 2. WebClient vs RestClient
- 구글 API 호출에 WebClient를 쓸지, RestClient를 쓸지 고민

**결론:**
- **RestClient 선택**
  - OAuth는 순차적 흐름 → 비동기 불필요
  - WebClient는 오버엔지니어링
  - RestClient가 더 간결하고 가독성 좋음
  - 별도 의존성 불필요
  
---
<br>

## 🚨 참고 사항